### PR TITLE
feat: add enable_render and disable_render for treeland-ddm protocol

### DIFF
--- a/xml/treeland-ddm-v1.xml
+++ b/xml/treeland-ddm-v1.xml
@@ -36,6 +36,18 @@
                 screen, but not to close the current seats.
             </description>
         </request>
+        <request name="enable_render">
+            <description summary="start treeland rendering">
+                Enable treeland rendering. This is primarily called after
+                disable_render to resume treeland.
+            </description>
+        </request>
+        <request name="disable_render">
+            <description summary="stop treeland rendering">
+                Disable treeland rendering. This will prevent treeland from
+                output to DRM device.
+            </description>
+        </request>
         <!-- Events -->
         <event name="switch_to_vt">
             <description summary="switch to virtual terminal">


### PR DESCRIPTION
Primarily solving wrongly display render issue when switching VT too quickly.