### PR TITLE
feat: Add callback for disable_render

### DIFF
--- a/xml/treeland-ddm-v1.xml
+++ b/xml/treeland-ddm-v1.xml
@@ -47,6 +47,7 @@
                 Disable treeland rendering. This will prevent treeland from
                 output to DRM device.
             </description>
+            <arg name="callback" type="new_id" interface="wl_callback"/>
         </request>
         <!-- Events -->
         <event name="switch_to_vt">


### PR DESCRIPTION
This is needed to ensure render is exactly disabled before DDM doing further actions.