### PR TITLE
chore: update debian changelog for new Wayland protocols

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+treeland-protocols (0.5.0-1splashscreen0) unstable; urgency=medium
+
+  * feat: add new Wayland protocols for app launching
+
+ -- rewine <luhongxu@uniontech.com>  Wed, 15 Oct 2025 14:14:17 +0800
+
 treeland-protocols (0.5.0) unstable; urgency=medium
 
   * feat: add treeland-ddm communication protocol


### PR DESCRIPTION
Update debian/changelog to reflect the addition of new Wayland protocols for app launching functionality. This change documents the version bump from 0.5.0 to 0.5.1-splashscreen0 and includes the necessary metadata for Debian package management.

Log: Added new Wayland protocols for app launching

Influence:
1. Verify package versioning and changelog formatting
2. Check Debian package build process with updated changelog
3. Confirm protocol availability in the built package
4. Test app launching functionality using the new protocols

chore: 更新 debian changelog 以支持新的 Wayland 协议

更新 debian/changelog 以反映新增的用于应用启动功能的 Wayland 协议。此更
改记录了版本从 0.5.0 升级到 0.5.1-splashscreen0，并包含了 Debian 包管理 所需的元数据。

Log: 新增用于应用启动的 Wayland 协议

Influence:
1. 验证包版本控制和 changelog 格式
2. 检查使用更新后的 changelog 的 Debian 包构建过程
3. 确认构建包中新协议的可用性
4. 测试使用新协议的应用启动功能