### PR TITLE
fix: correct nonexistent enum reference in protocol

### DIFF
--- a/xml/treeland-capture-unstable-v1.xml
+++ b/xml/treeland-capture-unstable-v1.xml
@@ -132,7 +132,7 @@
         Provides flags about the frame. This event is sent once before the
         "ready" event.
       </description>
-      <arg name="flags" type="uint" enum="treeland_capture_once_context_v1.flags" summary="frame flags"/>
+      <arg name="flags" type="uint" enum="treeland_capture_frame_v1.flags" summary="frame flags"/>
     </event>
 
     <event name="ready">


### PR DESCRIPTION
The enum reference for the "flags" argument in the event was incorrectly set to "treeland_capture_once_context_v1.flags", which does not exist. It has been corrected to "treeland_capture_frame_v1.flags" to match the actual enum definition. This fix ensures proper protocol validation and prevents runtime errors due to missing enum references.

事件中 "flags" 参数的枚举引用原本错误地设置为
"treeland_capture_once_context_v1.flags"，该枚举并不存在。现已更正为实际 存在的 "treeland_capture_frame_v1.flags"。此修复可确保协议验证正确，避免 因缺失枚举引用导致的运行时错误。