### PR TITLE
fix: treeland-shortcut-manager-v2: update keybind_mode enum definition

### DIFF
--- a/xml/treeland-shortcut-manager-v2.xml
+++ b/xml/treeland-shortcut-manager-v2.xml
@@ -4,7 +4,7 @@
     SPDX-FileCopyrightText: 2024-2025 UnionTech Software Technology Co., Ltd.
     SPDX-License-Identifier: MIT
     ]]></copyright>
-    <interface name="treeland_shortcut_manager_v2" version="1">
+    <interface name="treeland_shortcut_manager_v2" version="2">
         <description summary="global shortcuts manager for treeland">
             This interface allows privileged clients to register global shortcuts.
 
@@ -12,7 +12,7 @@
             Shortcuts for different users are isolated, and will not interfere with each other.
             This allows multiple users to use their own set of global Shortcuts
             on the same system without conflicts.
-            This behavior is transparent to the clients of this interface (i.e 
+            This behavior is transparent to the clients of this interface (i.e
             the user context used by this protocol is the same as that of the client.)
 
             Warning! The protocol described in this file is currently in the testing
@@ -21,14 +21,14 @@
             only be done by creating a new major version of the extension.
         </description>
 
-        <request name="destroy" type="destructor">
+        <request name="destroy" type="destructor" since="1">
             <description summary="destroy the shortcut manager">
                 Destroy the shortcut manager.
                 Existing shortcuts created through this interface remain valid.
             </description>
         </request>
 
-        <request name="acquire">
+        <request name="acquire" since="1">
             <description summary="acquire the shortcut manager">
                 Acquire the shortcut manager for the current client.
 
@@ -40,7 +40,7 @@
             </description>
         </request>
 
-        <request name="bind_key">
+        <request name="bind_key" since="1">
             <description summary="bind a key sequence to a compositor action">
                 Bind a key sequence to a compositor action.
 
@@ -56,24 +56,21 @@
                 The action argument specifies the compositor action to be executed
                 when the key sequence is activated.
 
-                The protocol provides three keybinding modes:
-                - key_release: the action is triggered when the key sequence is released.
-                - key_press: the action is triggered when the key sequence is pressed.
-                - key_press_repeat: the action is triggered when the key sequence is pressed,
-                  and repeatedly triggered if the key sequence is held down.
+                Each keybind has a flags argument to specify the exact condition of triggering,
+                see documentation of keybind_flag enum for details.
 
                 If a binding with the same key sequence and action already exists,
-                the bind_key request will fail.
+                its flags will be updated to the new value.
 
                 Note that the binding will not take effect until a commit request is sent.
             </description>
             <arg name="name" type="string" summary="unique name for the keybinding"/>
             <arg name="key" type="string" summary="key sequence for the keybinding"/>
-            <arg name="mode" type="uint" enum="keybind_mode" summary="mode for the keybinding"/>
+            <arg name="flags" type="uint" enum="keybind_flag" summary="flags for the keybinding"/>
             <arg name="action" type="uint" enum="action" summary="compositor action to be executed"/>
         </request>
 
-        <request name="bind_swipe_gesture">
+        <request name="bind_swipe_gesture" since="1">
             <description summary="bind a swipe gesture to a compositor action">
                 Bind a swipe gesture to a compositor action.
 
@@ -99,7 +96,7 @@
             <arg name="action" type="uint" enum="action" summary="compositor action to be executed"/>
         </request>
 
-        <request name="bind_hold_gesture">
+        <request name="bind_hold_gesture" since="1">
             <description summary="bind a hold gesture to a compositor action">
                 Bind a hold gesture to a compositor action.
 
@@ -121,7 +118,7 @@
             <arg name="action" type="uint" enum="action" summary="compositor action to be executed"/>
         </request>
 
-        <request name="commit">
+        <request name="commit" since="1">
             <description summary="commit the pending bindings">
                 Commit the pending bindings.
 
@@ -142,7 +139,7 @@
             </description>
         </request>
 
-        <request name="unbind">
+        <request name="unbind" since="1">
             <description summary="remove an existing binding">
                 Remove an existing binding.
 
@@ -152,24 +149,24 @@
             <arg name="name" type="string" summary="unique name of the binding to be removed"/>
         </request>
 
-        <event name="activated">
+        <event name="activated" since="1">
             <description summary="a shortcut has been activated">
                 This event is emitted when a binding registered with action `notify` is activated.
 
-                If the binding is activated due to auto-repeat, the repeat argument will be non-zero.
+                the flags argument indicates the type of key event as defined in keybind_flag enum.
             </description>
             <arg name="name" type="string" summary="binding id of the activated shortcut"/>
-            <arg name="repeat" type="uint" summary="indicates whether the shortcut activation is due to auto-repeat"/>
+            <arg name="flags" type="uint" enum="keybind_flag" summary="flags for the key event"/>
         </event>
 
-        <event name="commit_success">
+        <event name="commit_success" since="1">
             <description summary="the last commit was successful">
                 This event is emitted in response to a commit request,
                 indicating that the commit was successful.
             </description>
         </event>
 
-        <event name="commit_failure">
+        <event name="commit_failure" since="1">
             <description summary="the last commit has failed">
                 This event is emitted in response to a commit request,
                 indicating that the commit has failed.
@@ -180,14 +177,14 @@
             <arg name="error" type="uint" enum="bind_error" summary="error code indicating the reason of the failure"/>
         </event>
 
-        <enum name="direction">
+        <enum name="direction" since="1">
             <entry name="down" value="1"/>
             <entry name="left" value="2"/>
             <entry name="up" value="3"/>
             <entry name="right" value="4"/>
         </enum>
 
-        <enum name="action">
+        <enum name="action" since="1">
             <description summary="compositor actions">
                 Compositor actions that can be assigned to a shortcut.
             </description>
@@ -220,16 +217,27 @@
             <entry name="taskswitch_sameapp_prev" value="27"/>
         </enum>
 
-        <enum name="keybind_mode">
-            <description summary="keybinding modes">
-                Keybinding modes.
+        <enum name="keybind_flag" bitfield="true" since="2">
+            <description summary="keybinding flags">
+                Flags to specify the keybinding mode.
+                with key_press, the action is triggered on key press.
+                with key_release, the action is triggered on key release.
+                with repeat, the action is repeatedly triggered if the key is held down.
+
+                Examples:
+                key_press | repeat: the action is triggered on key press, and repeatedly
+                                    triggered if the key is held down.
+                key_press | key_release: the action is triggered on both key press and
+                                         key release, auto-repeated events are ignored.
+                key_press | key_release | repeat: note that treeland repeats both key
+                                                  press and key release events.
             </description>
-            <entry name="key_release" value="1"/>
-            <entry name="key_press" value="2"/>
-            <entry name="key_press_repeat" value="3"/>
+            <entry name="key_press" value="0x1" summary="bind key press events"/>
+            <entry name="key_release" value="0x2" summary="bind key release events"/>
+            <entry name="repeat" value="0x4" summary="bind autorepeat events."/>
         </enum>
 
-        <enum name="bind_error">
+        <enum name="bind_error" since="1">
             <description summary="binding error codes">
                 Error codes indicating the reason of a binding failure.
             </description>
@@ -239,7 +247,7 @@
             <entry name="internal_error" value="4"/>
         </enum>
 
-        <enum name="error">
+        <enum name="error" since="1">
             <entry name="occupied" value="1"/>
             <entry name="not_acquired" value="2"/>
             <entry name="invalid_commit" value="3"/>


### PR DESCRIPTION
Since treeland repeats both pressed and released key events, keybind_mode should be adjusted to allow binding to only non-repeated key release events as well.