### PR TITLE
feat: add prelaunch splash screen protocol v2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ set(XML
   xml/treeland-ddm-v1.xml
   xml/treeland-screensaver-v1.xml
   xml/treeland-prelaunch-splash-v1.xml
+  xml/treeland-prelaunch-splash-v2.xml
   xml/treeland-app-id-resolver-v1.xml
   xml/treeland-wallpaper-manager-unstable-v1.xml
   xml/treeland-wallpaper-shell-unstable-v1.xml

--- a/xml/treeland-prelaunch-splash-v2.xml
+++ b/xml/treeland-prelaunch-splash-v2.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="treeland_prelaunch_splash_v2">
+
+    <copyright><![CDATA[
+    SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+    SPDX-License-Identifier: MIT
+    ]]></copyright>
+
+    <interface name="treeland_prelaunch_splash_manager_v2" version="1">
+        <description summary="prelaunch splash screen manager">
+            This interface is a manager for creating prelaunch splash screens.
+            A prelaunch splash screen is a placeholder surface that is shown
+            before an application's main window is mapped. This helps to improve
+            the perceived startup time.
+
+            It is particularly useful for application launchers to provide immediate
+            feedback to the user.
+
+            Compared to treeland_prelaunch_splash_manager_v1, this version returns
+            a splash object from create_splash. The caller can destroy the object
+            to dismiss the splash, and the compositor can send events (e.g. timeout)
+            back to the caller through the object.
+        </description>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the manager"/>
+        </request>
+
+        <request name="create_splash">
+            <description summary="create a new splash screen">
+                Creates a new prelaunch splash screen and returns a splash object.
+
+                The `app_id` is a string that identifies the application. The compositor
+                will use this ID together with `sandbox_engine_name` to match the splash
+                screen with the actual application window when it appears. This
+                matching mechanism should also work for XWayland windows.
+
+                The `instance_id` identifies a specific application instance, allowing
+                multiple splashes for non-singleton applications. The compositor can
+                use this to associate a splash with a particular launch instance.
+
+                Callers MUST provide a non-empty `sandbox_engine_name` string which
+                identifies the sandboxing/container.
+            </description>
+            <arg name="splash" type="new_id" interface="treeland_prelaunch_splash_v2" summary="new splash object"/>
+            <arg name="app_id" type="string" summary="the application ID"/>
+            <arg name="instance_id" type="string" summary="the application instance ID"/>
+            <arg name="sandbox_engine_name" type="string" summary="the sandbox engine / security context name (required, non-empty)"/>
+            <arg name="icon_buffer" type="object" interface="wl_buffer" allow-null="true" summary="optional icon image as wl_buffer (e.g. wl_shm)"/>
+        </request>
+    </interface>
+
+    <interface name="treeland_prelaunch_splash_v2" version="1">
+        <description summary="prelaunch splash screen object">
+            Represents a single prelaunch splash screen created by the manager.
+
+            The caller can destroy this object to dismiss the corresponding splash.
+            The compositor may also send events through this object, for example
+            to notify the caller that the splash was closed due to a timeout.
+        </description>
+
+        <request name="destroy" type="destructor">
+            <description summary="dismiss and destroy the splash">
+                Dismisses the splash screen and destroys this object.
+            </description>
+        </request>
+    </interface>
+</protocol>


### PR DESCRIPTION
Added new Wayland protocol treeland-prelaunch-splash-v2.xml to support enhanced prelaunch splash screen functionality. This version introduces a splash object that allows bidirectional communication between the compositor and applications. Key improvements include proper object lifecycle management where callers can destroy splash objects to dismiss them, and compositors can send events like timeouts back to callers. The protocol also adds support for instance IDs to handle multiple application instances and requires sandbox engine names for security context identification.

Log: Added new prelaunch splash screen protocol with enhanced object management and bidirectional communication

Influence:
1. Test splash screen creation with valid app_id, instance_id, and sandbox_engine_name
2. Verify splash object destruction properly dismisses the splash screen
3. Test compositor events like timeout notifications through the splash object
4. Validate multiple splash instances for non-singleton applications
5. Check XWayland window matching with splash screens
6. Test optional icon buffer functionality with null and valid buffers

feat: 添加预启动闪屏协议 v2 版本

新增 Wayland 协议 treeland-prelaunch-splash-v2.xml 以支持增强的预启动闪 屏功能。此版本引入了闪屏对象，支持合成器和应用程序之间的双向通信。主要改
进包括正确的对象生命周期管理，调用者可以销毁闪屏对象来关闭闪屏，合成器可
以通过对象发送超时等事件给调用者。协议还增加了实例 ID 支持以处理多个应用
程序实例，并要求沙盒引擎名称用于安全上下文识别。

Log: 新增预启动闪屏协议，支持增强的对象管理和双向通信

Influence:
1. 测试使用有效的 app_id、instance_id 和 sandbox_engine_name 创建闪屏
2. 验证销毁闪屏对象是否正确关闭闪屏
3. 测试合成器通过闪屏对象发送的超时等事件通知
4. 验证非单例应用程序的多个闪屏实例
5. 检查 XWayland 窗口与闪屏的匹配机制
6. 测试可选图标缓冲区功能，包括空值和有效缓冲区