### PR TITLE
treeland-protocols: add wine wayland protocols

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,8 @@ set(XML
   xml/treeland-app-id-resolver-v1.xml
   xml/treeland-wallpaper-manager-unstable-v1.xml
   xml/treeland-wallpaper-shell-unstable-v1.xml
+  xml/treeland-wine-window-management-unstable-v1.xml
+  xml/treeland-wine-window-state-unstable-v1.xml
 )
 
 install(FILES ${XML} DESTINATION ${CMAKE_INSTALL_DATADIR}/treeland-protocols)

--- a/xml/treeland-wine-window-management-unstable-v1.xml
+++ b/xml/treeland-wine-window-management-unstable-v1.xml
@@ -38,10 +38,9 @@
 
     <interface name="treeland_wine_window_manager_v1" version="1">
         <description summary="global entry point for Wine window management">
-            A global singleton that lets a Wine client create per-toplevel
-            control objects.  The compositor should restrict binding to
-            trusted clients identified by app_id or an equivalent policy
-            mechanism.
+            Lets a Wine client create per-toplevel control objects.  The
+            compositor should restrict binding to trusted clients identified
+            by app_id or an equivalent policy mechanism.
 
             The client must destroy all child
             treeland_wine_window_control_v1 objects before destroying this
@@ -87,35 +86,24 @@
             coordinate space (the same space used by wl_output.geometry and
             xdg_output.logical_position).
 
-            Position and size requests are not applied immediately.  The
-            compositor processes them and reports the result in a
-            configure_geometry event followed by a done event.  The client
-            should treat the values in configure_geometry as authoritative
-            and update its internal state accordingly.
+            Position requests are not applied immediately.  The
+            compositor processes them and reports the result via
+            configure_position.  The client should treat the values in
+            configure_position as authoritative and update its internal
+            state accordingly.
 
             If the associated xdg_toplevel is destroyed, this object becomes
             inert.  All subsequent requests are ignored and no further events
             are emitted.  The client should destroy the inert object.
+
+            Window size is managed through the standard xdg_toplevel
+            configure / xdg_surface.ack_configure mechanism.  This interface
+            only controls screen position and stacking order.
         </description>
 
         <enum name="error">
-            <entry name="invalid_size" value="0"
-                summary="requested width or height is non-positive"/>
-            <entry name="invalid_sibling" value="1"
+            <entry name="invalid_sibling" value="0"
                 summary="sibling_id is non-zero for an op that does not accept a sibling"/>
-        </enum>
-
-        <enum name="swp_flags" bitfield="true">
-            <description summary="SetWindowPos flag mask">
-                Bitfield controlling which geometry fields set_geometry
-                should apply.  Unset bits cause the compositor to preserve
-                the current value.  Corresponds to SWP_NOMOVE and SWP_NOSIZE
-                in the Windows SetWindowPos API.
-            </description>
-            <entry name="nomove" value="1"
-                summary="ignore x and y; preserve current position"/>
-            <entry name="nosize" value="2"
-                summary="ignore width and height; preserve current size"/>
         </enum>
 
         <enum name="z_order_op">
@@ -155,30 +143,34 @@
             </description>
         </request>
 
-        <request name="set_geometry">
-            <description summary="request new position and/or size atomically">
-                Requests that the compositor change the window's position
-                and/or size.  The flags bitfield controls which fields to
-                apply, corresponding to the SWP_NOMOVE and SWP_NOSIZE flags
-                of the Windows SetWindowPos API.
+        <request name="set_position">
+            <description summary="request a new absolute screen position">
+                Requests that the compositor place this window at the
+                specified position in the compositor's global logical
+                coordinate space.
 
-                Width and height must be positive when the nosize flag is
-                not set; otherwise the compositor must raise an invalid_size
-                error.
+                The requested position must fall within the bounds of an
+                active screen.  If the compositor determines that
+                (x, y) is outside all screen regions, it rejects the
+                request and emits a configure_position event reporting the
+                current unchanged position.
 
-                The compositor may adjust the values based on policy and
-                reports the actual placement via configure_geometry followed
-                by done.
+                Even for valid positions the compositor does not guarantee
+                exact placement: it may adjust the position to respect
+                window management rules or layer-shell exclusive zones.
+                The client must treat the values in the resulting
+                configure_position event as authoritative and update its
+                internal state accordingly.
 
-                Corresponds to the position and size component of the
-                Windows SetWindowPos and MoveWindow APIs.
+                Window size changes must use the standard xdg_toplevel
+                configure / xdg_surface.ack_configure flow and are outside
+                the scope of this protocol.
+
+                Corresponds to the position component of the Windows
+                SetWindowPos and MoveWindow APIs.
             </description>
             <arg name="x" type="int" summary="desired x in global logical coordinates"/>
             <arg name="y" type="int" summary="desired y in global logical coordinates"/>
-            <arg name="width" type="int" summary="desired width in logical coordinates"/>
-            <arg name="height" type="int" summary="desired height in logical coordinates"/>
-            <arg name="flags" type="uint" enum="swp_flags"
-                summary="which geometry fields to apply"/>
         </request>
 
         <request name="set_z_order">
@@ -203,7 +195,10 @@
                 to hwnd_top within the appropriate tier.
 
                 The compositor reports the resulting stacking state via
-                configure_stacking followed by done.
+                configure_stacking.
+
+                Note: hwnd_top and hwnd_insert_after do not change tier
+                membership and therefore do not emit configure_stacking.
             </description>
             <arg name="op" type="uint" enum="z_order_op"
                 summary="Z-order operation"/>
@@ -229,26 +224,26 @@
             <arg name="id" type="uint" summary="non-zero session-scoped window identifier"/>
         </event>
 
-        <event name="configure_geometry">
-            <description summary="compositor reports actual window geometry">
+        <event name="configure_position">
+            <description summary="compositor reports actual window position">
                 Sent by the compositor to inform the client of the actual
-                window position and size in global logical coordinates.
+                window position in the compositor's global logical coordinate
+                space.
 
                 This event is emitted:
                 - immediately after window_id on initial creation,
-                - in response to set_geometry requests,
-                - when the user or compositor moves or resizes the window.
+                - in response to set_position requests,
+                - when the user or compositor moves the window.
 
-                The client should use these values to synchronize its
+                Window size is communicated via the standard xdg_toplevel
+                configure event and is not reported here.
+
+                The client should use these coordinates to synchronize its
                 internal window state (e.g. update the wineserver window
-                rectangles).
-
-                This event is always followed by a done event.
+                rectangles with the correct screen origin).
             </description>
             <arg name="x" type="int" summary="actual x in global logical coordinates"/>
             <arg name="y" type="int" summary="actual y in global logical coordinates"/>
-            <arg name="width" type="int" summary="actual width in logical coordinates"/>
-            <arg name="height" type="int" summary="actual height in logical coordinates"/>
         </event>
 
         <event name="configure_stacking">
@@ -257,7 +252,7 @@
                 currently in the topmost tier (WS_EX_TOPMOST equivalent).
 
                 This event is emitted:
-                - immediately after window_id and configure_geometry on
+                - immediately after window_id and configure_position on
                   initial creation, to report the current tier state,
                 - in response to set_z_order requests that change tier
                   membership (hwnd_topmost, hwnd_notopmost, hwnd_bottom),
@@ -265,25 +260,10 @@
 
                 Note: hwnd_top and hwnd_insert_after do not change tier
                 membership and therefore do not trigger this event.
-
-                This event is always followed by a done event.
             </description>
             <arg name="topmost" type="uint"
                 summary="non-zero if the toplevel is in the topmost tier"/>
         </event>
 
-        <event name="done">
-            <description summary="end of a configure sequence">
-                Marks the end of an atomic set of configure events.  The
-                client should apply all preceding configure_geometry and
-                configure_stacking values as one update after receiving
-                this event.
-
-                The serial is this protocol's own sequence counter and is
-                independent of the xdg_surface configure serial space.
-                Clients must not pass this serial to xdg_surface.ack_configure.
-            </description>
-            <arg name="serial" type="uint" summary="configure serial for this protocol"/>
-        </event>
     </interface>
 </protocol>

--- a/xml/treeland-wine-window-management-unstable-v1.xml
+++ b/xml/treeland-wine-window-management-unstable-v1.xml
@@ -1,0 +1,289 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="treeland_wine_window_management_v1">
+    <copyright><![CDATA[
+    SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+    SPDX-License-Identifier: MIT
+    ]]></copyright>
+
+    <description summary="window geometry and stacking control for Wine">
+        This protocol provides privileged window management capabilities
+        required by Wine (the Windows API compatibility layer) that are not
+        available through standard Wayland protocols.
+
+        Standard xdg-shell intentionally prevents clients from setting their
+        own screen position or controlling z-order.  Wine applications rely
+        heavily on absolute positioning (SetWindowPos, MoveWindow) and
+        stacking control (HWND_TOPMOST, HWND_TOP) to implement the Windows
+        window management model.  This protocol bridges that gap by allowing
+        a trusted Wine client to request positioning and stacking changes
+        while leaving the compositor the final authority over actual
+        placement.
+
+        A client obtains a treeland_wine_window_control_v1 object for each
+        xdg_toplevel it wishes to manage.  Requests on that object express
+        the client's desired geometry and stacking.  The compositor applies
+        or adjusts them and reports the actual result through events.
+
+        A Wine session is the set of all treeland_wine_window_control_v1
+        objects created through the same treeland_wine_window_manager_v1
+        global binding.  window_id values emitted by the window_id event are
+        unique and valid only within that set.  The compositor must enforce
+        this boundary: a sibling_id supplied to set_z_order that refers to a
+        control object from a different manager binding must be treated as if
+        no matching sibling exists (i.e., fall back to hwnd_top behavior).
+
+        The key words "must", "must not", "should", "should not", and "may"
+        in this document are to be interpreted as described in IETF RFC 2119.
+    </description>
+
+    <interface name="treeland_wine_window_manager_v1" version="1">
+        <description summary="global entry point for Wine window management">
+            A global singleton that lets a Wine client create per-toplevel
+            control objects.  The compositor should restrict binding to
+            trusted clients identified by app_id or an equivalent policy
+            mechanism.
+
+            The client must destroy all child
+            treeland_wine_window_control_v1 objects before destroying this
+            object.
+        </description>
+
+        <enum name="error">
+            <entry name="toplevel_already_controlled" value="0"
+                summary="a control object already exists for the given toplevel"/>
+            <entry name="defunct_toplevel" value="1"
+                summary="the xdg_toplevel has no associated role or has been destroyed"/>
+        </enum>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the manager">
+                Destroys this manager object.  The client must destroy every
+                treeland_wine_window_control_v1 created through this manager
+                before sending this request; otherwise the compositor must
+                raise an implementation-defined protocol error.
+            </description>
+        </request>
+
+        <request name="get_window_control">
+            <description summary="create a control object for an xdg_toplevel">
+                Creates a treeland_wine_window_control_v1 bound to the given
+                xdg_toplevel.  At most one control object may exist for each
+                toplevel; requesting a second one is a
+                toplevel_already_controlled error.  If the xdg_toplevel has
+                been destroyed or has no configured role the compositor must
+                raise a defunct_toplevel error.
+            </description>
+            <arg name="id" type="new_id" interface="treeland_wine_window_control_v1"/>
+            <arg name="toplevel" type="object" interface="xdg_toplevel"/>
+        </request>
+    </interface>
+
+    <interface name="treeland_wine_window_control_v1" version="1">
+        <description summary="per-toplevel position, size, and stacking control">
+            Controls the screen geometry and stacking order for one
+            xdg_toplevel surface.
+
+            All coordinate values are in the compositor's global logical
+            coordinate space (the same space used by wl_output.geometry and
+            xdg_output.logical_position).
+
+            Position and size requests are not applied immediately.  The
+            compositor processes them and reports the result in a
+            configure_geometry event followed by a done event.  The client
+            should treat the values in configure_geometry as authoritative
+            and update its internal state accordingly.
+
+            If the associated xdg_toplevel is destroyed, this object becomes
+            inert.  All subsequent requests are ignored and no further events
+            are emitted.  The client should destroy the inert object.
+        </description>
+
+        <enum name="error">
+            <entry name="invalid_size" value="0"
+                summary="requested width or height is non-positive"/>
+            <entry name="invalid_sibling" value="1"
+                summary="sibling_id is non-zero for an op that does not accept a sibling"/>
+        </enum>
+
+        <enum name="swp_flags" bitfield="true">
+            <description summary="SetWindowPos flag mask">
+                Bitfield controlling which geometry fields set_geometry
+                should apply.  Unset bits cause the compositor to preserve
+                the current value.  Corresponds to SWP_NOMOVE and SWP_NOSIZE
+                in the Windows SetWindowPos API.
+            </description>
+            <entry name="nomove" value="1"
+                summary="ignore x and y; preserve current position"/>
+            <entry name="nosize" value="2"
+                summary="ignore width and height; preserve current size"/>
+        </enum>
+
+        <enum name="z_order_op">
+            <description summary="Z-order operation matching Windows SetWindowPos hWndInsertAfter">
+                Encodes the Windows SetWindowPos hWndInsertAfter parameter
+                directly.  The first four values correspond to the four
+                special HWND constants.  hwnd_insert_after requires a
+                non-zero sibling_id in set_z_order.
+
+                hwnd_topmost and hwnd_notopmost change WS_EX_TOPMOST tier
+                membership; the compositor must preserve the resulting tier
+                until explicitly changed.  hwnd_bottom also clears topmost.
+                hwnd_top does not alter tier membership.
+
+                This is a superset of what the Wine X11 driver implements:
+                the X11 driver tracks only the topmost flag and a boolean
+                "raise to top", skipping HWND_BOTTOM and sibling-relative
+                ordering (see sync_window_position comment in winex11.drv).
+                This protocol implements all five Windows cases.
+            </description>
+            <entry name="hwnd_top" value="0"
+                summary="raise to top of current tier; no tier change (HWND_TOP)"/>
+            <entry name="hwnd_bottom" value="1"
+                summary="lower to absolute bottom of Z-order; clears topmost (HWND_BOTTOM)"/>
+            <entry name="hwnd_topmost" value="2"
+                summary="enter topmost tier at its top; sets WS_EX_TOPMOST (HWND_TOPMOST)"/>
+            <entry name="hwnd_notopmost" value="3"
+                summary="leave topmost tier; raise to top of normal tier (HWND_NOTOPMOST)"/>
+            <entry name="hwnd_insert_after" value="4"
+                summary="place directly below the sibling identified by sibling_id"/>
+        </enum>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy this control object">
+                Destroys the control object.  This does not affect the
+                associated xdg_toplevel or its current position on screen.
+            </description>
+        </request>
+
+        <request name="set_geometry">
+            <description summary="request new position and/or size atomically">
+                Requests that the compositor change the window's position
+                and/or size.  The flags bitfield controls which fields to
+                apply, corresponding to the SWP_NOMOVE and SWP_NOSIZE flags
+                of the Windows SetWindowPos API.
+
+                Width and height must be positive when the nosize flag is
+                not set; otherwise the compositor must raise an invalid_size
+                error.
+
+                The compositor may adjust the values based on policy and
+                reports the actual placement via configure_geometry followed
+                by done.
+
+                Corresponds to the position and size component of the
+                Windows SetWindowPos and MoveWindow APIs.
+            </description>
+            <arg name="x" type="int" summary="desired x in global logical coordinates"/>
+            <arg name="y" type="int" summary="desired y in global logical coordinates"/>
+            <arg name="width" type="int" summary="desired width in logical coordinates"/>
+            <arg name="height" type="int" summary="desired height in logical coordinates"/>
+            <arg name="flags" type="uint" enum="swp_flags"
+                summary="which geometry fields to apply"/>
+        </request>
+
+        <request name="set_z_order">
+            <description summary="request a Z-order change using Windows SetWindowPos semantics">
+                Requests a Z-order change that directly encodes the Windows
+                SetWindowPos hWndInsertAfter parameter.
+
+                For ops hwnd_top, hwnd_bottom, hwnd_topmost, and
+                hwnd_notopmost, sibling_id must be 0; a non-zero value is
+                an invalid_sibling error.
+
+                For op hwnd_insert_after, sibling_id must be the window_id
+                of a control object in the same Wine session as emitted by
+                the window_id event on that control.  The compositor places
+                this surface directly below the identified sibling in
+                Z-order.  If sibling_id is 0 or does not identify a live
+                surface in the same session, the compositor must treat the
+                request as hwnd_top.
+
+                hwnd_insert_after must not mix tiers: if the sibling is in
+                a different tier from this surface, the compositor must clamp
+                to hwnd_top within the appropriate tier.
+
+                The compositor reports the resulting stacking state via
+                configure_stacking followed by done.
+            </description>
+            <arg name="op" type="uint" enum="z_order_op"
+                summary="Z-order operation"/>
+            <arg name="sibling_id" type="uint"
+                summary="window_id of the sibling for hwnd_insert_after; 0 for all other ops"/>
+        </request>
+
+        <event name="window_id">
+            <description summary="compositor-assigned session-scoped identifier">
+                Emitted by the compositor immediately after this control
+                object is created, before any configure_geometry or
+                configure_stacking event.
+
+                The id is a non-zero uint32 that uniquely identifies this
+                toplevel within the current Wine session for the lifetime of
+                this control object.
+
+                The Wine driver must store this mapping (HWND to window_id)
+                in wineserver shared memory so that other Wine processes in
+                the same session can look up the sibling_id to use in
+                set_z_order requests.
+            </description>
+            <arg name="id" type="uint" summary="non-zero session-scoped window identifier"/>
+        </event>
+
+        <event name="configure_geometry">
+            <description summary="compositor reports actual window geometry">
+                Sent by the compositor to inform the client of the actual
+                window position and size in global logical coordinates.
+
+                This event is emitted:
+                - immediately after window_id on initial creation,
+                - in response to set_geometry requests,
+                - when the user or compositor moves or resizes the window.
+
+                The client should use these values to synchronize its
+                internal window state (e.g. update the wineserver window
+                rectangles).
+
+                This event is always followed by a done event.
+            </description>
+            <arg name="x" type="int" summary="actual x in global logical coordinates"/>
+            <arg name="y" type="int" summary="actual y in global logical coordinates"/>
+            <arg name="width" type="int" summary="actual width in logical coordinates"/>
+            <arg name="height" type="int" summary="actual height in logical coordinates"/>
+        </event>
+
+        <event name="configure_stacking">
+            <description summary="compositor reports actual topmost tier state">
+                Sent by the compositor to report whether this toplevel is
+                currently in the topmost tier (WS_EX_TOPMOST equivalent).
+
+                This event is emitted:
+                - immediately after window_id and configure_geometry on
+                  initial creation, to report the current tier state,
+                - in response to set_z_order requests that change tier
+                  membership (hwnd_topmost, hwnd_notopmost, hwnd_bottom),
+                - when the compositor changes tiers on its own initiative.
+
+                Note: hwnd_top and hwnd_insert_after do not change tier
+                membership and therefore do not trigger this event.
+
+                This event is always followed by a done event.
+            </description>
+            <arg name="topmost" type="uint"
+                summary="non-zero if the toplevel is in the topmost tier"/>
+        </event>
+
+        <event name="done">
+            <description summary="end of a configure sequence">
+                Marks the end of an atomic set of configure events.  The
+                client should apply all preceding configure_geometry and
+                configure_stacking values as one update after receiving
+                this event.
+
+                The serial is this protocol's own sequence counter and is
+                independent of the xdg_surface configure serial space.
+                Clients must not pass this serial to xdg_surface.ack_configure.
+            </description>
+            <arg name="serial" type="uint" summary="configure serial for this protocol"/>
+        </event>
+    </interface>
+</protocol>

--- a/xml/treeland-wine-window-state-unstable-v1.xml
+++ b/xml/treeland-wine-window-state-unstable-v1.xml
@@ -1,0 +1,367 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="treeland_wine_window_state_v1">
+    <copyright><![CDATA[
+    SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+    SPDX-License-Identifier: MIT
+    ]]></copyright>
+
+    <description summary="window state query and control for Wine">
+        This protocol provides window state management capabilities required
+        by Wine (the Windows API compatibility layer) that are not available
+        through standard Wayland protocols.
+
+        Standard xdg-shell lacks:
+        - any way to read whether a toplevel is minimized,
+        - any way to programmatically unminimize a toplevel,
+        - any way to request activation without a valid xdg-activation token
+          originating from a prior user interaction,
+        - any way to request a visual attention hint (taskbar flash) without
+          stealing focus,
+        - any pointer grab mechanism for cross-window drag or menu tracking.
+
+        This protocol fills those gaps.  A client obtains a
+        treeland_wine_window_state_v1 object for each xdg_toplevel whose
+        state it needs to observe or control.  The compositor remains the
+        final authority: every request is advisory, and the compositor
+        reports the authoritative state through events.
+
+        The key words "must", "must not", "should", "should not", and "may"
+        in this document are to be interpreted as described in IETF RFC 2119.
+    </description>
+
+    <interface name="treeland_wine_window_state_manager_v1" version="1">
+        <description summary="global entry point for Wine window state control">
+            A global singleton that lets a Wine client create per-toplevel
+            state objects.  The compositor should restrict binding to
+            trusted clients identified by app_id or an equivalent policy
+            mechanism.
+
+            The client must destroy all child
+            treeland_wine_window_state_v1 objects before destroying this
+            object.
+        </description>
+
+        <enum name="error">
+            <entry name="toplevel_already_bound" value="0"
+                summary="a state object already exists for the given toplevel"/>
+            <entry name="defunct_toplevel" value="1"
+                summary="the xdg_toplevel has no associated role or has been destroyed"/>
+        </enum>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the manager">
+                Destroys this manager object.  The client must destroy every
+                treeland_wine_window_state_v1 created through this manager
+                before sending this request; otherwise the compositor must
+                raise an implementation-defined protocol error.
+            </description>
+        </request>
+
+        <request name="get_window_state">
+            <description summary="create a state object for an xdg_toplevel">
+                Creates a treeland_wine_window_state_v1 bound to the given
+                xdg_toplevel.  At most one state object may exist for each
+                toplevel; requesting a second one is a
+                toplevel_already_bound error.  If the xdg_toplevel has been
+                destroyed or has no configured role, the compositor must
+                raise a defunct_toplevel error.
+
+                Upon creation, the compositor immediately sends a full
+                state_changed event followed by a done event to report the
+                current state of the toplevel.
+            </description>
+            <arg name="id" type="new_id" interface="treeland_wine_window_state_v1"/>
+            <arg name="toplevel" type="object" interface="xdg_toplevel"/>
+        </request>
+    </interface>
+
+    <interface name="treeland_wine_window_state_v1" version="1">
+        <description summary="per-toplevel state observation and control">
+            Observes and controls the lifecycle state for one xdg_toplevel
+            surface.
+
+            State flags are reported via the state_changed event.  Each
+            flag corresponds to a Windows window state that xdg-shell does
+            not expose to clients.
+
+            If the associated xdg_toplevel is destroyed, this object
+            becomes inert.  All subsequent requests are ignored and no
+            further events are emitted.  The client should destroy the
+            inert object.
+        </description>
+
+        <enum name="state" bitfield="true">
+            <description summary="window state flags">
+                Bitfield of window states that the compositor tracks for
+                this toplevel.  These supplement the states delivered by
+                xdg_toplevel.configure.  Keyboard focus (activated) is
+                excluded because it is already delivered by xdg_toplevel;
+                duplicating it here would create two conflicting sources of
+                truth.
+            </description>
+            <entry name="minimized" value="1"
+                summary="the toplevel is minimized (iconified)"/>
+            <entry name="attention" value="2"
+                summary="the toplevel is requesting user attention (taskbar flash active)"/>
+        </enum>
+
+        <enum name="activate_reason">
+            <description summary="reason for an activation request">
+                Provides semantic context for an activate request so the
+                compositor can apply appropriate focus-stealing prevention
+                policy.
+            </description>
+            <entry name="user_request" value="0"
+                summary="the user explicitly asked to activate this window (e.g. taskbar click)"/>
+            <entry name="programmatic" value="1"
+                summary="the application is activating itself (e.g. SetForegroundWindow without direct user gesture)"/>
+            <entry name="restore" value="2"
+                summary="the window is being restored from a minimized or hidden state"/>
+        </enum>
+
+        <enum name="grab_reason">
+            <description summary="reason for a pointer grab">
+                Indicates why the client needs to receive pointer events
+                outside its window bounds.  The compositor may apply
+                different policies depending on the reason.
+            </description>
+            <entry name="move_resize" value="0"
+                summary="interactive window move or resize in progress"/>
+            <entry name="menu" value="1"
+                summary="popup menu tracking in progress"/>
+        </enum>
+
+        <enum name="grab_end_reason">
+            <description summary="why a pointer grab ended">
+                Indicates the cause of a pointer_grab_ended event so the
+                Wine driver can update its internal SetCapture state
+                correctly.
+            </description>
+            <entry name="client_request" value="0"
+                summary="the client called release_pointer_grab"/>
+            <entry name="button_released" value="1"
+                summary="all pointer buttons were released; applies to move_resize grabs"/>
+            <entry name="compositor_revoked" value="2"
+                summary="the compositor revoked the grab due to policy or focus change"/>
+        </enum>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy this state object">
+                Destroys the state object.  Any active pointer grab
+                associated with this object is released by the compositor;
+                however, no pointer_grab_ended event is emitted as part of
+                this destruction.  The client must not send
+                release_pointer_grab after calling destroy.  This does not
+                affect the associated xdg_toplevel.
+            </description>
+        </request>
+
+        <request name="unminimize">
+            <description summary="request that the toplevel be unminimized">
+                Requests that the compositor restore this toplevel from the
+                minimized state.
+
+                Standard xdg-shell provides xdg_toplevel.set_minimized but
+                no way to reverse it.  This request fills that gap.
+
+                If the toplevel is not currently minimized, this request has
+                no effect.  If the compositor honors the request, it emits a
+                state_changed event with the minimized flag cleared, followed
+                by a done event.
+
+                This corresponds to the Wine/Windows ShowWindow(SW_RESTORE)
+                call on a minimized window.
+            </description>
+        </request>
+
+        <request name="activate">
+            <description summary="request that the toplevel be activated">
+                Requests that the compositor give keyboard focus to this
+                toplevel and raise it in the stacking order.
+
+                serial is a client-assigned value that is echoed back in
+                any activate_denied event for this request, allowing the
+                client to correlate denials when multiple activations are
+                in flight.
+
+                The reason argument informs the compositor about the context
+                of the activation.  Compositors should generally honor
+                user_request and restore activations, and may choose to
+                deny or convert programmatic activations into attention
+                requests based on focus-stealing prevention policy.
+
+                If the compositor denies the request, it emits an
+                activate_denied event carrying the same serial, and may
+                set the attention flag via state_changed.
+
+                Corresponds to the Wine/Windows SetForegroundWindow API.
+                Under X11, Wine sends a _NET_ACTIVE_WINDOW client message
+                with source indication; this request serves the same role
+                under Wayland.
+            </description>
+            <arg name="serial" type="uint"
+                summary="client-assigned serial for correlating with activate_denied"/>
+            <arg name="reason" type="uint" enum="activate_reason"
+                summary="why the client is requesting activation"/>
+            <arg name="seat" type="object" interface="wl_seat"
+                summary="the seat on which to activate"/>
+        </request>
+
+        <request name="set_attention">
+            <description summary="request a user attention hint (taskbar flash)">
+                Asks the compositor to display a visual hint that this
+                toplevel needs user attention, typically by flashing or
+                highlighting its entry in the taskbar.  This must not
+                steal keyboard focus.
+
+                count specifies how many times to flash.  0 means flash
+                indefinitely until the window is activated, corresponding
+                to FLASHW_TIMER in the Windows FlashWindowEx API.
+
+                timeout_ms specifies the interval between flashes in
+                milliseconds.  0 uses the compositor default blink rate,
+                corresponding to the system cursor blink rate in Windows.
+
+                Sending this request replaces any currently active
+                attention hint.  To stop flashing, use clear_attention.
+
+                Corresponds to FlashWindowEx with FLASHW_ALL | FLASHW_TRAY.
+                Under X11, Wine sets _NET_WM_STATE_DEMANDS_ATTENTION;
+                this request serves the same role under Wayland.
+            </description>
+            <arg name="count" type="uint"
+                summary="number of flashes; 0 for indefinite"/>
+            <arg name="timeout_ms" type="uint"
+                summary="flash interval in milliseconds; 0 for compositor default"/>
+        </request>
+
+        <request name="clear_attention">
+            <description summary="cancel a user attention hint">
+                Cancels any active attention hint set via set_attention.
+                If no hint is active, this request has no effect.
+
+                The compositor emits a state_changed event with the
+                attention flag cleared, followed by done.
+
+                Corresponds to FlashWindowEx with FLASHW_STOP.
+            </description>
+        </request>
+
+        <request name="set_pointer_grab">
+            <description summary="grab pointer events outside the window">
+                Requests that the compositor redirect all pointer events to
+                this toplevel's surface, even when the pointer is outside
+                the surface bounds.  This is required for interactive
+                window move/resize and popup menu tracking, where the
+                pointer may leave the window area while a button is held.
+
+                The reason argument indicates why the grab is needed.  The
+                compositor may use this to scope the grab appropriately —
+                for example, automatically releasing the grab when all
+                pointer buttons are released for a move_resize grab.
+
+                If a grab is already active, sending this request replaces
+                it with a new grab using the specified reason.  To release
+                a grab, use the release_pointer_grab request instead.
+
+                This corresponds to the X11 XGrabPointer call that Wine
+                uses in its SetCapture implementation for GUI_INMOVESIZE
+                and GUI_INMENUMODE scenarios.
+
+                The compositor must send a pointer_grab_ended event when
+                the grab terminates, whether by client request, button
+                release, or compositor policy.
+            </description>
+            <arg name="seat" type="object" interface="wl_seat"
+                summary="the seat whose pointer should be grabbed"/>
+            <arg name="reason" type="uint" enum="grab_reason"
+                summary="why the grab is needed"/>
+        </request>
+
+        <request name="release_pointer_grab">
+            <description summary="release a previously set pointer grab">
+                Explicitly releases any active pointer grab set via
+                set_pointer_grab for the given seat.  If no grab is active
+                on that seat, this request has no effect.
+
+                The compositor sends a pointer_grab_ended event after
+                processing this request.
+            </description>
+            <arg name="seat" type="object" interface="wl_seat"
+                summary="the seat whose pointer grab should be released"/>
+        </request>
+
+        <event name="state_changed">
+            <description summary="window state flags have changed">
+                Emitted whenever the state flags of the toplevel change.
+
+                This event is sent:
+                - immediately after the treeland_wine_window_state_v1 is
+                  created, to report current state,
+                - when the user or compositor minimizes or restores the
+                  window,
+                - when an attention hint is set or cleared.
+
+                The state argument is a bitfield of treeland_wine_window_state_v1.state
+                values.  Flags not present in the bitfield are considered
+                unset.
+
+                This event is always followed by a done event.  The client
+                should not act on individual state_changed events but wait
+                for done to apply the complete set atomically.
+            </description>
+            <arg name="state" type="uint" enum="state"
+                summary="current state bitfield"/>
+        </event>
+
+        <event name="activate_denied">
+            <description summary="activation request was denied">
+                Emitted when the compositor denies an activate request.
+                The serial matches the serial field of the activate request
+                that was denied.
+
+                The compositor may have set the attention flag via
+                state_changed instead.  The client must not retry the
+                activation automatically.
+
+                This event is always followed by a done event.
+            </description>
+            <arg name="serial" type="uint"
+                summary="serial from the corresponding activate request"/>
+        </event>
+
+        <event name="pointer_grab_ended">
+            <description summary="pointer grab has been released">
+                Emitted when a pointer grab established via set_pointer_grab
+                is released.  The seat argument identifies which seat's grab
+                ended, matching the seat argument that was passed to
+                set_pointer_grab.  The reason argument indicates why the
+                grab ended; the Wine driver uses this to update SetCapture
+                state:
+                - client_request: client called release_pointer_grab,
+                - button_released: all buttons released (move_resize grabs),
+                - compositor_revoked: policy or focus change.
+
+                After this event the client must not assume pointer events
+                from the named seat are still being redirected.
+            </description>
+            <arg name="seat" type="object" interface="wl_seat"
+                summary="the seat whose pointer grab ended"/>
+            <arg name="reason" type="uint" enum="grab_end_reason"
+                summary="why the grab ended"/>
+        </event>
+
+        <event name="done">
+            <description summary="end of an event sequence">
+                Marks the end of an atomic set of state events.  The client
+                should apply all preceding state_changed and activate_denied
+                values accumulated since the last done event as one atomic
+                update after receiving this event.
+
+                A single done event may follow multiple state_changed or
+                activate_denied events.  The client must not act on any
+                individual event in the sequence before done is received.
+            </description>
+        </event>
+    </interface>
+</protocol>

--- a/xml/treeland-wine-window-state-unstable-v1.xml
+++ b/xml/treeland-wine-window-state-unstable-v1.xml
@@ -16,8 +16,7 @@
         - any way to request activation without a valid xdg-activation token
           originating from a prior user interaction,
         - any way to request a visual attention hint (taskbar flash) without
-          stealing focus,
-        - any pointer grab mechanism for cross-window drag or menu tracking.
+          stealing focus.
 
         This protocol fills those gaps.  A client obtains a
         treeland_wine_window_state_v1 object for each xdg_toplevel whose
@@ -31,10 +30,9 @@
 
     <interface name="treeland_wine_window_state_manager_v1" version="1">
         <description summary="global entry point for Wine window state control">
-            A global singleton that lets a Wine client create per-toplevel
-            state objects.  The compositor should restrict binding to
-            trusted clients identified by app_id or an equivalent policy
-            mechanism.
+            Lets a Wine client create per-toplevel state objects.  The
+            compositor should restrict binding to trusted clients identified
+            by app_id or an equivalent policy mechanism.
 
             The client must destroy all child
             treeland_wine_window_state_v1 objects before destroying this
@@ -66,9 +64,9 @@
                 destroyed or has no configured role, the compositor must
                 raise a defunct_toplevel error.
 
-                Upon creation, the compositor immediately sends a full
-                state_changed event followed by a done event to report the
-                current state of the toplevel.
+                Upon creation, the compositor immediately sends a
+                state_changed event to report the current state of the
+                toplevel.
             </description>
             <arg name="id" type="new_id" interface="treeland_wine_window_state_v1"/>
             <arg name="toplevel" type="object" interface="xdg_toplevel"/>
@@ -119,18 +117,8 @@
                 summary="the window is being restored from a minimized or hidden state"/>
         </enum>
 
-        <enum name="grab_reason">
-            <description summary="reason for a pointer grab">
-                Indicates why the client needs to receive pointer events
-                outside its window bounds.  The compositor may apply
-                different policies depending on the reason.
-            </description>
-            <entry name="move_resize" value="0"
-                summary="interactive window move or resize in progress"/>
-            <entry name="menu" value="1"
-                summary="popup menu tracking in progress"/>
-        </enum>
-
+        <!-- grab_end_reason enum and pointer grab requests are temporarily
+             omitted pending security review of the grab mechanism.
         <enum name="grab_end_reason">
             <description summary="why a pointer grab ended">
                 Indicates the cause of a pointer_grab_ended event so the
@@ -140,19 +128,16 @@
             <entry name="client_request" value="0"
                 summary="the client called release_pointer_grab"/>
             <entry name="button_released" value="1"
-                summary="all pointer buttons were released; applies to move_resize grabs"/>
+                summary="all pointer buttons were released"/>
             <entry name="compositor_revoked" value="2"
                 summary="the compositor revoked the grab due to policy or focus change"/>
         </enum>
+        -->
 
         <request name="destroy" type="destructor">
             <description summary="destroy this state object">
-                Destroys the state object.  Any active pointer grab
-                associated with this object is released by the compositor;
-                however, no pointer_grab_ended event is emitted as part of
-                this destruction.  The client must not send
-                release_pointer_grab after calling destroy.  This does not
-                affect the associated xdg_toplevel.
+                Destroys the state object.  This does not affect the
+                associated xdg_toplevel.
             </description>
         </request>
 
@@ -166,8 +151,7 @@
 
                 If the toplevel is not currently minimized, this request has
                 no effect.  If the compositor honors the request, it emits a
-                state_changed event with the minimized flag cleared, followed
-                by a done event.
+                state_changed event with the minimized flag cleared.
 
                 This corresponds to the Wine/Windows ShowWindow(SW_RESTORE)
                 call on a minimized window.
@@ -190,6 +174,16 @@
                 deny or convert programmatic activations into attention
                 requests based on focus-stealing prevention policy.
 
+                If the compositor accepts the request, no activate_denied
+                event is sent.  Acceptance does not guarantee immediate
+                keyboard focus: if another surface (e.g. a layer-shell
+                surface with exclusive keyboard interactivity) currently
+                holds focus, the compositor places this toplevel at the
+                head of the focus fallback queue and activates it once
+                the exclusive focus is released.  The client will
+                observe the eventual focus grant through the normal
+                xdg_toplevel.configure activated state.
+
                 If the compositor denies the request, it emits an
                 activate_denied event carrying the same serial, and may
                 set the attention flag via state_changed.
@@ -209,30 +203,40 @@
 
         <request name="set_attention">
             <description summary="request a user attention hint (taskbar flash)">
-                Asks the compositor to display a visual hint that this
-                toplevel needs user attention, typically by flashing or
-                highlighting its entry in the taskbar.  This must not
-                steal keyboard focus.
+                Asks the compositor to signal that this toplevel needs user
+                attention in the taskbar or dock.  This must not steal
+                keyboard focus.
+
+                The compositor forwards this hint to the taskbar via the
+                foreign toplevel manager protocol.  Whether the taskbar
+                honors count and timeout_ms is implementation-defined and
+                not guaranteed by the compositor; clients must not rely on
+                exact flash behavior.
 
                 count specifies how many times to flash.  0 means flash
                 indefinitely until the window is activated, corresponding
                 to FLASHW_TIMER in the Windows FlashWindowEx API.
 
-                timeout_ms specifies the interval between flashes in
-                milliseconds.  0 uses the compositor default blink rate,
-                corresponding to the system cursor blink rate in Windows.
+                timeout_ms specifies the desired interval between flashes
+                in milliseconds.  0 requests the compositor or taskbar
+                default rate.  This value is forwarded as a hint only.
 
                 Sending this request replaces any currently active
                 attention hint.  To stop flashing, use clear_attention.
 
-                Corresponds to FlashWindowEx with FLASHW_ALL | FLASHW_TRAY.
+                This request covers the taskbar/tray component
+                (FLASHW_TRAY) of the Windows FlashWindowEx API.
+                Title-bar caption flashing (FLASHW_CAPTION) is handled
+                by Wine's client-side decoration layer and is outside
+                the scope of this protocol.
+
                 Under X11, Wine sets _NET_WM_STATE_DEMANDS_ATTENTION;
                 this request serves the same role under Wayland.
             </description>
             <arg name="count" type="uint"
                 summary="number of flashes; 0 for indefinite"/>
             <arg name="timeout_ms" type="uint"
-                summary="flash interval in milliseconds; 0 for compositor default"/>
+                summary="desired flash interval in milliseconds; 0 for default; forwarded as a hint only"/>
         </request>
 
         <request name="clear_attention">
@@ -241,32 +245,29 @@
                 If no hint is active, this request has no effect.
 
                 The compositor emits a state_changed event with the
-                attention flag cleared, followed by done.
+                attention flag cleared.
 
                 Corresponds to FlashWindowEx with FLASHW_STOP.
             </description>
         </request>
 
+        <!-- set_pointer_grab and release_pointer_grab are temporarily omitted
+             pending security review. The scope of this grab is broad and
+             requires additional compositor policy definition before exposing.
         <request name="set_pointer_grab">
             <description summary="grab pointer events outside the window">
                 Requests that the compositor redirect all pointer events to
                 this toplevel's surface, even when the pointer is outside
-                the surface bounds.  This is required for interactive
-                window move/resize and popup menu tracking, where the
-                pointer may leave the window area while a button is held.
-
-                The reason argument indicates why the grab is needed.  The
-                compositor may use this to scope the grab appropriately —
-                for example, automatically releasing the grab when all
-                pointer buttons are released for a move_resize grab.
+                the surface bounds.  This is required for popup menu
+                tracking, where the pointer may leave the menu window area
+                while a button is held.
 
                 If a grab is already active, sending this request replaces
-                it with a new grab using the specified reason.  To release
-                a grab, use the release_pointer_grab request instead.
+                it.  To release a grab, use the release_pointer_grab
+                request instead.
 
                 This corresponds to the X11 XGrabPointer call that Wine
-                uses in its SetCapture implementation for GUI_INMOVESIZE
-                and GUI_INMENUMODE scenarios.
+                uses in its SetCapture implementation for GUI_INMENUMODE.
 
                 The compositor must send a pointer_grab_ended event when
                 the grab terminates, whether by client request, button
@@ -274,8 +275,6 @@
             </description>
             <arg name="seat" type="object" interface="wl_seat"
                 summary="the seat whose pointer should be grabbed"/>
-            <arg name="reason" type="uint" enum="grab_reason"
-                summary="why the grab is needed"/>
         </request>
 
         <request name="release_pointer_grab">
@@ -290,6 +289,7 @@
             <arg name="seat" type="object" interface="wl_seat"
                 summary="the seat whose pointer grab should be released"/>
         </request>
+        -->
 
         <event name="state_changed">
             <description summary="window state flags have changed">
@@ -305,10 +305,6 @@
                 The state argument is a bitfield of treeland_wine_window_state_v1.state
                 values.  Flags not present in the bitfield are considered
                 unset.
-
-                This event is always followed by a done event.  The client
-                should not act on individual state_changed events but wait
-                for done to apply the complete set atomically.
             </description>
             <arg name="state" type="uint" enum="state"
                 summary="current state bitfield"/>
@@ -323,13 +319,12 @@
                 The compositor may have set the attention flag via
                 state_changed instead.  The client must not retry the
                 activation automatically.
-
-                This event is always followed by a done event.
             </description>
             <arg name="serial" type="uint"
                 summary="serial from the corresponding activate request"/>
         </event>
 
+        <!-- pointer_grab_ended event omitted together with set_pointer_grab.
         <event name="pointer_grab_ended">
             <description summary="pointer grab has been released">
                 Emitted when a pointer grab established via set_pointer_grab
@@ -339,7 +334,7 @@
                 grab ended; the Wine driver uses this to update SetCapture
                 state:
                 - client_request: client called release_pointer_grab,
-                - button_released: all buttons released (move_resize grabs),
+                - button_released: all pointer buttons released,
                 - compositor_revoked: policy or focus change.
 
                 After this event the client must not assume pointer events
@@ -350,18 +345,7 @@
             <arg name="reason" type="uint" enum="grab_end_reason"
                 summary="why the grab ended"/>
         </event>
+        -->
 
-        <event name="done">
-            <description summary="end of an event sequence">
-                Marks the end of an atomic set of state events.  The client
-                should apply all preceding state_changed and activate_denied
-                values accumulated since the last done event as one atomic
-                update after receiving this event.
-
-                A single done event may follow multiple state_changed or
-                activate_denied events.  The client must not act on any
-                individual event in the sequence before done is received.
-            </description>
-        </event>
     </interface>
 </protocol>

--- a/xml/treeland-wine-window-state-unstable-v1.xml
+++ b/xml/treeland-wine-window-state-unstable-v1.xml
@@ -117,23 +117,6 @@
                 summary="the window is being restored from a minimized or hidden state"/>
         </enum>
 
-        <!-- grab_end_reason enum and pointer grab requests are temporarily
-             omitted pending security review of the grab mechanism.
-        <enum name="grab_end_reason">
-            <description summary="why a pointer grab ended">
-                Indicates the cause of a pointer_grab_ended event so the
-                Wine driver can update its internal SetCapture state
-                correctly.
-            </description>
-            <entry name="client_request" value="0"
-                summary="the client called release_pointer_grab"/>
-            <entry name="button_released" value="1"
-                summary="all pointer buttons were released"/>
-            <entry name="compositor_revoked" value="2"
-                summary="the compositor revoked the grab due to policy or focus change"/>
-        </enum>
-        -->
-
         <request name="destroy" type="destructor">
             <description summary="destroy this state object">
                 Destroys the state object.  This does not affect the
@@ -251,46 +234,6 @@
             </description>
         </request>
 
-        <!-- set_pointer_grab and release_pointer_grab are temporarily omitted
-             pending security review. The scope of this grab is broad and
-             requires additional compositor policy definition before exposing.
-        <request name="set_pointer_grab">
-            <description summary="grab pointer events outside the window">
-                Requests that the compositor redirect all pointer events to
-                this toplevel's surface, even when the pointer is outside
-                the surface bounds.  This is required for popup menu
-                tracking, where the pointer may leave the menu window area
-                while a button is held.
-
-                If a grab is already active, sending this request replaces
-                it.  To release a grab, use the release_pointer_grab
-                request instead.
-
-                This corresponds to the X11 XGrabPointer call that Wine
-                uses in its SetCapture implementation for GUI_INMENUMODE.
-
-                The compositor must send a pointer_grab_ended event when
-                the grab terminates, whether by client request, button
-                release, or compositor policy.
-            </description>
-            <arg name="seat" type="object" interface="wl_seat"
-                summary="the seat whose pointer should be grabbed"/>
-        </request>
-
-        <request name="release_pointer_grab">
-            <description summary="release a previously set pointer grab">
-                Explicitly releases any active pointer grab set via
-                set_pointer_grab for the given seat.  If no grab is active
-                on that seat, this request has no effect.
-
-                The compositor sends a pointer_grab_ended event after
-                processing this request.
-            </description>
-            <arg name="seat" type="object" interface="wl_seat"
-                summary="the seat whose pointer grab should be released"/>
-        </request>
-        -->
-
         <event name="state_changed">
             <description summary="window state flags have changed">
                 Emitted whenever the state flags of the toplevel change.
@@ -323,29 +266,6 @@
             <arg name="serial" type="uint"
                 summary="serial from the corresponding activate request"/>
         </event>
-
-        <!-- pointer_grab_ended event omitted together with set_pointer_grab.
-        <event name="pointer_grab_ended">
-            <description summary="pointer grab has been released">
-                Emitted when a pointer grab established via set_pointer_grab
-                is released.  The seat argument identifies which seat's grab
-                ended, matching the seat argument that was passed to
-                set_pointer_grab.  The reason argument indicates why the
-                grab ended; the Wine driver uses this to update SetCapture
-                state:
-                - client_request: client called release_pointer_grab,
-                - button_released: all pointer buttons released,
-                - compositor_revoked: policy or focus change.
-
-                After this event the client must not assume pointer events
-                from the named seat are still being redirected.
-            </description>
-            <arg name="seat" type="object" interface="wl_seat"
-                summary="the seat whose pointer grab ended"/>
-            <arg name="reason" type="uint" enum="grab_end_reason"
-                summary="why the grab ended"/>
-        </event>
-        -->
 
     </interface>
 </protocol>


### PR DESCRIPTION
Add the first cut of the Wine-specific Wayland protocol split for Treeland.

- add treeland_wine_window_management_v1 for SetWindowPos-style geometry and Z-order control
- add treeland_wine_window_state_v1 for minimize, activation, attention, and pointer grab state
- register both protocol XML files in the install list

This keeps Wine window management and state control separate so each area can evolve independently while still matching the Windows API model more closely than xdg-shell.