### PR TITLE
feat: add treeland-input-manager-unstable-v1 protocol

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(XML
   xml/treeland-wallpaper-shell-unstable-v1.xml
   xml/treeland-wine-window-management-unstable-v1.xml
   xml/treeland-wine-window-state-unstable-v1.xml
+  xml/treeland-input-manager-unstable-v1.xml
 )
 
 install(FILES ${XML} DESTINATION ${CMAKE_INSTALL_DATADIR}/treeland-protocols)

--- a/xml/treeland-input-manager-unstable-v1.xml
+++ b/xml/treeland-input-manager-unstable-v1.xml
@@ -1,0 +1,807 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="treeland_input_manager_unstable_v1">
+    <copyright><![CDATA[
+    SPDX-FileCopyrightText: 2026 UnionTech Software Technology Co., Ltd.
+    SPDX-License-Identifier: MIT
+    ]]></copyright>
+
+    <description summary="configure input devices managed by treeland">
+        This protocol allows a privileged client to discover seat capabilities
+        and configure compositor-managed mouse, touchpad, and keyboard devices.
+
+        A treeland_input_manager_v1 object is a global manager. It creates
+        settings objects that represent configuration state for existing input
+        devices; those settings objects are not the device objects themselves.
+
+        For mouse and touchpad devices, pointer device settings such as
+        acceleration speed, acceleration profile, natural scrolling, scroll
+        factor, handed mode, double-click interval, send events mode,
+        disable-while-typing and tap-to-click are managed through a
+        treeland_pointer_device_configuration_v1 object created from the
+        device-specific settings interface. The lifetime of a settings object
+        is independent from the wl_seat object used to identify the target at
+        creation time.
+    </description>
+
+    <interface name="treeland_input_manager_v1" version="1">
+        <description summary="global input device manager">
+            The treeland_input_manager_v1 interface is a global object used to
+            create per-device settings objects for input devices exposed by the
+            compositor.
+
+            The compositor advertises device capability changes with the
+            capability_available and capability_unavailable events.
+
+            For each target device or seat-level settings scope, the compositor
+            may allow at most one live settings object of a given interface
+            created from one manager object.
+
+            virtual-pointer and virtual-keyboard are not included in the list.
+        </description>
+
+        <enum name="device_type" bitfield="true">
+            <entry name="mouse" value="1"
+                   summary="mouse input device"/>
+            <entry name="touchpad" value="2"
+                   summary="touchpad input device"/>
+            <entry name="keyboard" value="4"
+                    summary="keyboard input device"/>
+        </enum>
+
+        <enum name="state">
+            <entry name="disabled" value="0" summary="disabled state"/>
+            <entry name="enabled" value="1" summary="enabled state"/>
+        </enum>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the input manager">
+                This informs the compositor that the treeland input manager object
+                will no longer be used.
+
+                Existing objects created through this interface are not destroyed
+                automatically. Clients should destroy those objects before destroying
+                the manager.
+            </description>
+        </request>
+
+        <request name="get_mouse_settings">
+            <description summary="create a mouse-specific settings object">
+                Create a treeland_mouse_settings_v1 object for the specified
+                seat.
+
+                The created object acts as a factory for
+                treeland_pointer_device_configuration_v1 objects that manage
+                mouse device settings on the target seat.
+
+                The seat must currently expose mouse capability. If the seat
+                does not identify a valid mouse-capable target, the compositor
+                raises the protocol error.
+            </description>
+            <arg name="id" type="new_id" interface="treeland_mouse_settings_v1"/>
+            <arg name="seat" type="object" interface="wl_seat"
+                 summary="seat whose mouse-specific settings are being managed"/>
+        </request>
+
+        <request name="get_touchpad_settings">
+            <description summary="create a touchpad-specific settings object">
+                Create a treeland_touchpad_settings_v1 object for the specified
+                seat.
+
+                The created object acts as a factory for
+                treeland_pointer_device_configuration_v1 objects that manage
+                touchpad device settings on the target seat.
+
+                The seat must currently expose touchpad capability. If the seat
+                does not identify a valid touchpad-capable target, the
+                compositor raises the protocol error.
+            </description>
+            <arg name="id" type="new_id" interface="treeland_touchpad_settings_v1"/>
+            <arg name="seat" type="object" interface="wl_seat"
+                 summary="seat whose touchpad-specific settings are being managed"/>
+        </request>
+
+        <request name="get_keyboard_settings">
+            <description summary="create a keyboard settings object">
+                Create a treeland_keyboard_settings_v1 object for the specified
+                seat.
+
+                The seat must currently expose keyboard capability. If the seat
+                does not identify a valid keyboard-capable target, the
+                compositor raises the protocol error.
+            </description>
+            <arg name="id" type="new_id" interface="treeland_keyboard_settings_v1"/>
+            <arg name="seat" type="object" interface="wl_seat"
+                 summary="seat whose keyboard-specific settings are being managed"/>
+        </request>
+
+        <event name="capability_available">
+            <description summary="report an available device capability">
+                This event is emitted when the compositor detects that a seat
+                now exposes the specified device capability.
+
+                The compositor sends this event immediately after the
+                treeland_input_manager_v1 object is created to report
+                capabilities currently available on a seat.
+
+                The compositor may also send this event later when input
+                devices are hot-plugged and a seat gains the specified
+                capability.
+
+                A client may create a treeland_mouse_settings_v1 object for a
+                given seat only if the compositor has advertised device_type
+                mouse capability for that seat. Likewise, a client may create a
+                treeland_touchpad_settings_v1 or treeland_keyboard_settings_v1
+                object for a given seat only if the compositor has advertised
+                device_type touchpad or keyboard capability for that seat.
+            </description>
+            <arg name="type" type="uint" enum="device_type"
+                 summary="type of the device capability"/>
+            <arg name="seat" type="object" interface="wl_seat"
+                 summary="seat associated with the capability"/>
+        </event>
+
+        <event name="capability_unavailable">
+            <description summary="report an unavailable device capability">
+                This event is emitted when the compositor detects that a seat no
+                longer exposes the specified device capability.
+
+                The compositor may also send this event later when input
+                devices are hot-unplugged and a seat loses the specified
+                capability.
+
+                If type includes mouse capability, the client must destroy any
+                treeland_mouse_settings_v1 objects targeting the seat. This
+                also destroys any treeland_pointer_device_configuration_v1
+                objects created from those mouse settings objects.
+
+                If type includes touchpad capability, the client must destroy
+                any treeland_touchpad_settings_v1 objects targeting the seat.
+                This also destroys any treeland_pointer_device_configuration_v1
+                objects created from those touchpad settings objects.
+
+                If type includes keyboard capability, the client must destroy any
+                treeland_keyboard_settings_v1 objects targeting the seat.
+            </description>
+            <arg name="type" type="uint" enum="device_type"
+                 summary="type of the device capability"/>
+            <arg name="seat" type="object" interface="wl_seat"
+                 summary="seat associated with the capability"/>
+        </event>
+    </interface>
+
+    <interface name="treeland_pointer_device_configuration_v1" version="1">
+        <description summary="pointer device configuration object">
+            The treeland_pointer_device_configuration_v1 interface represents
+            pending configuration for pointer devices associated with the parent
+            device settings object.
+
+            This object is created via get_pointer_configuration on a
+            treeland_mouse_settings_v1 or treeland_touchpad_settings_v1 object.
+            It collects configuration that applies to the associated device
+            type.
+
+            Requests on this object update pending state. The compositor
+            applies the accumulated settings when the client sends apply.
+            Destroying the object before apply discards any pending state that
+            has not yet been applied.
+
+            The compositor sends configuration events after object creation to
+            report the current effective settings. It may later send additional
+            state batches when those effective settings change for
+            compositor-defined reasons. A done event terminates each event
+            batch.
+        </description>
+
+        <enum name="feature" bitfield="true">
+            <description summary="pointer device features">
+                Optional features supported by pointer devices. The compositor
+                sends a feature event to indicate which features are supported
+                by at least one device associated with the parent settings
+                object. A client must only send a set request if the
+                corresponding feature has been advertised. It is a protocol error
+                to send a set request for a feature that has not been
+                advertised.
+            </description>
+            <entry name="scroll_factor" value="1"
+                   summary="device supports configuring scroll factor"/>
+            <entry name="handed_mode" value="2"
+                   summary="device supports configuring handed mode"/>
+            <entry name="accel_speed" value="4"
+                   summary="device supports configuring acceleration speed"/>
+            <entry name="acceleration_profile" value="8"
+                   summary="device supports configuring acceleration profile"/>
+            <entry name="send_events_mode" value="16"
+                   summary="device supports configuring event delivery mode"/>
+            <entry name="natural_scroll" value="32"
+                   summary="device supports configuring natural scrolling"/>
+            <entry name="disable_while_typing" value="64"
+                   summary="device supports disable-while-typing"/>
+            <entry name="tap_to_click" value="128"
+                   summary="device supports tap-to-click"/>
+        </enum>
+
+        <enum name="handed_mode">
+            <entry name="right" value="0" summary="right-handed mode"/>
+            <entry name="left" value="1" summary="left-handed mode"/>
+        </enum>
+
+        <enum name="acceleration_profile" bitfield="true">
+            <description summary="pointer acceleration profiles">
+                Pointer acceleration profiles. The semantics correspond to
+                libinput acceleration profiles.
+            </description>
+            <entry name="none" value="0"
+                   summary="device does not have a configurable acceleration profile"/>
+            <entry name="flat" value="1"
+                   summary="use a flat acceleration profile"/>
+            <entry name="adaptive" value="2"
+                   summary="use an adaptive acceleration profile"/>
+            <entry name="custom" value="4"
+                   summary="use a custom acceleration profile"/>
+        </enum>
+
+        <enum name="send_events_mode">
+            <description summary="pointer event delivery mode">
+                Modes controlling whether the target pointer device should send
+                events and whether those events depend on the presence of an
+                external pointer device on the same seat.
+            </description>
+            <entry name="enabled" value="0"
+                   summary="send events from this device normally"/>
+            <entry name="disabled" value="1"
+                   summary="do not send events from this device"/>
+            <entry name="disabled_on_external_mouse" value="2"
+                   summary="if an external pointer device is plugged in, do not send events from this device; may be available on built-in pointer devices"/>
+        </enum>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the pointer device configuration object">
+                Destroy this treeland_pointer_device_configuration_v1 object.
+
+                Destroying the object discards any pending state that has not
+                yet been applied.
+            </description>
+        </request>
+
+        <request name="set_scroll_factor">
+            <description summary="set the scroll delta scaling factor">
+                Set a scaling factor applied to scroll axis deltas generated
+                by wheel and other continuous scrolling input sources. This
+                request requires the scroll_factor feature to be advertised via
+                the feature event.
+
+                The compositor multiplies scroll axis values by the specified
+                factor before forwarding them to clients. This affects
+                continuous scroll deltas only and does not modify discrete
+                scroll step events.
+
+                This request updates only the pending state associated with
+                this object. The change takes effect after the next apply
+                request.
+
+                Sending this request or the corresponding apply request does
+                not by itself cause a scroll_factor event to be emitted.
+
+                deltas = factor * _deltas
+            </description>
+
+            <arg name="factor"
+                type="fixed"
+                summary="scaling factor applied to scroll axis deltas"/>
+        </request>
+
+        <request name="set_handed_mode">
+            <description summary="set the handedness mode">
+                Set whether primary and secondary buttons use left-handed or
+                right-handed ordering. This request requires the handed_mode
+                feature to be advertised via the feature event. The change
+                takes effect on the next apply request.
+
+                This request updates only the pending state tracked by this
+                object. Sending this request, or the following apply request,
+                does not by itself cause a handed_mode event to be emitted.
+            </description>
+            <arg name="mode" type="uint" enum="handed_mode"
+                 summary="desired handedness mode"/>
+        </request>
+
+        <request name="set_accel_speed">
+            <description summary="set the pointer acceleration speed">
+                Set the pointer acceleration speed. This request requires the
+                accel_speed feature to be advertised via the feature event. The
+                change takes effect on the next apply request.
+
+                This request updates only the pending state tracked by this
+                object. Sending this request, or the following apply request,
+                does not by itself cause an accel_speed event to be emitted.
+            </description>
+            <arg name="accel_speed" type="fixed"
+                 summary="desired pointer acceleration speed"/>
+        </request>
+
+        <request name="set_acceleration_profile">
+            <description summary="set the acceleration profile">
+                Set the acceleration profile. This request requires the
+                acceleration_profile feature to be advertised via the feature
+                event. The change takes effect on the next apply request.
+
+                This request updates only the pending state tracked by this
+                object. Sending this request, or the following apply request,
+                does not by itself cause an acceleration_profile event to be
+                emitted.
+            </description>
+            <arg name="profile" type="uint" enum="treeland_pointer_device_configuration_v1.acceleration_profile"
+                 summary="desired acceleration profile"/>
+        </request>
+
+        <request name="set_send_events_mode">
+            <description summary="set the pointer event delivery mode">
+                Set how events from the target pointer device are delivered.
+                This request requires the send_events_mode feature to be
+                advertised via the feature event. The change takes effect on the
+                next apply request.
+
+                This request updates only the pending state tracked by this
+                object. Sending this request, or the following apply request,
+                does not by itself cause a send_events_mode event to be emitted.
+            </description>
+            <arg name="mode" type="uint" enum="treeland_pointer_device_configuration_v1.send_events_mode"
+                 summary="desired pointer event delivery mode"/>
+        </request>
+
+        <request name="set_natural_scroll">
+            <description summary="enable or disable natural scrolling">
+                Enable or disable natural scrolling. This request requires the
+                natural_scroll feature to be advertised via the feature event.
+                The change takes effect on the next apply request.
+
+                This request updates only the pending state tracked by this
+                object. Sending this request, or the following apply request,
+                does not by itself cause a natural_scroll event to be emitted.
+            </description>
+            <arg name="state" type="uint" enum="treeland_input_manager_v1.state"
+                 summary="desired natural scrolling state"/>
+        </request>
+
+        <request name="set_disable_while_typing">
+            <description summary="set disable-while-typing">
+                Enable or disable temporarily disabling pointer devices while
+                the user is typing. This request requires the
+                disable_while_typing feature to be advertised via the feature
+                event. The change takes effect on the next apply request.
+
+                This request updates only the pending state tracked by this
+                object. Sending this request, or the following apply request,
+                does not by itself cause a disable_while_typing event to be
+                emitted.
+            </description>
+            <arg name="state" type="uint" enum="treeland_input_manager_v1.state"
+                 summary="desired disable-while-typing state"/>
+        </request>
+
+        <request name="set_tap_to_click">
+            <description summary="set tap-to-click">
+                Enable or disable tap-to-click. This request requires the
+                tap_to_click feature to be advertised via the feature event.
+                The change takes effect on the next apply request.
+
+                This request updates only the pending state tracked by this
+                object. Sending this request, or the following apply request,
+                does not by itself cause a tap_to_click event to be emitted.
+            </description>
+            <arg name="state" type="uint" enum="treeland_input_manager_v1.state"
+                 summary="desired tap-to-click state"/>
+        </request>
+
+        <request name="apply">
+            <description summary="apply pending pointer device configuration changes">
+                Ask the compositor to apply the pending pointer device
+                configuration carried by this object.
+            </description>
+        </request>
+
+        <event name="feature">
+            <description summary="report supported pointer device features">
+                This event reports which optional features are supported by at
+                least one device associated with the parent settings object.
+
+                The compositor sends this event as part of the initial state
+                batch after the treeland_pointer_device_configuration_v1 object
+                is created.
+
+                The compositor may also send this event again when devices are
+                added to or removed from the target seat and the set of
+                supported features changes.
+            </description>
+            <arg name="feature" type="uint" enum="feature"
+                 summary="supported pointer device features"/>
+        </event>
+
+        <event name="scroll_factor">
+            <description summary="report the current scroll factor">
+                This event reports the current scroll factor used for wheel and
+                similar scroll input.
+
+                The compositor sends this event immediately after the
+                treeland_pointer_device_configuration_v1 object is created as
+                part of the initial state batch.
+
+                Changes requested through set_scroll_factor do not cause this
+                event to be emitted automatically.
+            </description>
+            <arg name="factor" type="fixed" summary="current scroll factor"/>
+        </event>
+
+        <event name="handed_mode">
+            <description summary="report the current handedness mode">
+                This event reports whether left-handed or right-handed button
+                ordering is currently used.
+
+                The compositor sends this event immediately after the
+                treeland_pointer_device_configuration_v1 object is created as
+                part of the initial state batch.
+
+                Changes requested through set_handed_mode do not cause this
+                event to be emitted automatically.
+            </description>
+            <arg name="mode" type="uint" enum="handed_mode"
+                 summary="current handedness mode"/>
+        </event>
+
+        <event name="accel_speed">
+            <description summary="report the current pointer acceleration speed">
+                This event reports the current pointer acceleration speed.
+
+                The compositor sends this event immediately after the
+                treeland_pointer_device_configuration_v1 object is created as
+                part of the initial state batch.
+
+                Changes requested through set_accel_speed do not cause this
+                event to be emitted automatically.
+            </description>
+            <arg name="accel_speed" type="fixed"
+                 summary="current pointer acceleration speed"/>
+        </event>
+
+        <event name="acceleration_profile">
+            <description summary="report the current acceleration profile">
+                This event reports the current acceleration profile.
+
+                The compositor sends this event immediately after the
+                treeland_pointer_device_configuration_v1 object is created as
+                part of the initial state batch.
+
+                Changes requested through set_acceleration_profile do not cause
+                this event to be emitted automatically.
+            </description>
+            <arg name="profile" type="uint" enum="treeland_pointer_device_configuration_v1.acceleration_profile"
+                 summary="current acceleration profile"/>
+        </event>
+
+        <event name="send_events_mode">
+            <description summary="report the current pointer event delivery mode">
+                This event reports the current event delivery mode used for
+                the target pointer device.
+
+                The compositor sends this event immediately after the
+                treeland_pointer_device_configuration_v1 object is created as
+                part of the initial state batch.
+
+                Changes requested through set_send_events_mode do not cause
+                this event to be emitted automatically.
+            </description>
+            <arg name="mode" type="uint" enum="treeland_pointer_device_configuration_v1.send_events_mode"
+                 summary="current pointer event delivery mode"/>
+        </event>
+
+        <event name="natural_scroll">
+            <description summary="report natural scrolling state">
+                This event reports whether natural scrolling is enabled.
+
+                The compositor sends this event immediately after the
+                treeland_pointer_device_configuration_v1 object is created as
+                part of the initial state batch.
+
+                Changes requested through set_natural_scroll do not cause this
+                event to be emitted automatically.
+            </description>
+            <arg name="state" type="uint" enum="treeland_input_manager_v1.state"
+                 summary="current natural scrolling state"/>
+        </event>
+
+        <event name="disable_while_typing">
+            <description summary="report disable-while-typing state">
+                This event reports whether pointer devices are temporarily
+                disabled while the user is typing.
+
+                The compositor sends this event as part of the initial state
+                batch if the disable_while_typing feature has been advertised.
+
+                Changes requested through set_disable_while_typing do not cause
+                this event to be emitted automatically.
+            </description>
+            <arg name="state" type="uint" enum="treeland_input_manager_v1.state"
+                 summary="current disable-while-typing state"/>
+        </event>
+
+        <event name="tap_to_click">
+            <description summary="report tap-to-click state">
+                This event reports whether tap-to-click is enabled.
+
+                The compositor sends this event as part of the initial state
+                batch if the tap_to_click feature has been advertised.
+
+                Changes requested through set_tap_to_click do not cause this
+                event to be emitted automatically.
+            </description>
+            <arg name="state" type="uint" enum="treeland_input_manager_v1.state"
+                 summary="current tap-to-click state"/>
+        </event>
+
+        <event name="failed">
+            <description summary="apply failed">
+                This event indicates that the compositor failed to apply one or
+                more pending pointer device configuration changes carried by
+                this object.
+
+                This event does not destroy the object. The client may continue
+                using the object and send further requests.
+            </description>
+        </event>
+
+        <event name="done">
+            <description summary="end of a pointer device state batch">
+                This event is sent once when all pointer device configuration
+                state events in the current batch have been sent.
+
+                The compositor must always end a batch of pointer device
+                configuration state events with this event, regardless of
+                whether it sends the initial state or a later update.
+
+                The serial is used in a future get_pointer_configuration
+                request to ensure the client's configuration is based on
+                up-to-date state.
+            </description>
+            <arg name="serial" type="uint" summary="current configuration serial"/>
+        </event>
+    </interface>
+
+    <interface name="treeland_mouse_settings_v1" version="1">
+        <description summary="mouse settings factory object">
+            The treeland_mouse_settings_v1 interface acts as a factory for
+            treeland_pointer_device_configuration_v1 objects that manage mouse
+            device settings on the target seat.
+
+            A treeland_pointer_device_configuration_v1 object is created via
+            get_pointer_configuration on this object.
+        </description>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the mouse settings object">
+                Destroy this treeland_mouse_settings_v1 object.
+
+                Existing treeland_pointer_device_configuration_v1 objects
+                created from this object are also destroyed.
+            </description>
+        </request>
+
+        <request name="get_pointer_configuration">
+            <description summary="create a pointer device configuration object">
+                Create a treeland_pointer_device_configuration_v1 object for
+                this mouse settings scope.
+
+                The created object manages mouse device configuration on the
+                target seat. The serial argument must match the serial from the
+                most recent done event sent on the previous
+                treeland_pointer_device_configuration_v1 object for this
+                treeland_mouse_settings_v1 object. For the first creation, the
+                serial should be 0.
+
+                Only one treeland_pointer_device_configuration_v1 object may
+                exist for this treeland_mouse_settings_v1 object at a time.
+                Creating a second one without destroying the first is a
+                protocol error.
+
+                If the serial does not match the current state, the compositor
+                may immediately send a failed event on the new
+                treeland_pointer_device_configuration_v1 object.
+            </description>
+            <arg name="id" type="new_id" interface="treeland_pointer_device_configuration_v1"/>
+            <arg name="serial" type="uint" summary="serial from the last done event"/>
+        </request>
+    </interface>
+
+    <interface name="treeland_touchpad_settings_v1" version="1">
+        <description summary="touchpad settings factory object">
+            The treeland_touchpad_settings_v1 interface acts as a factory for
+            treeland_pointer_device_configuration_v1 objects that manage
+            touchpad device settings on the target seat.
+
+            A treeland_pointer_device_configuration_v1 object is created via
+            get_pointer_configuration on this object.
+        </description>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the touchpad settings object">
+                Destroy this treeland_touchpad_settings_v1 object.
+
+                Existing treeland_pointer_device_configuration_v1 objects
+                created from this object are also destroyed.
+            </description>
+        </request>
+
+        <request name="get_pointer_configuration">
+            <description summary="create a pointer device configuration object">
+                Create a treeland_pointer_device_configuration_v1 object for
+                this touchpad settings scope.
+
+                The created object manages touchpad device configuration on the
+                target seat. The serial argument must match the serial from the
+                most recent done event sent on the previous
+                treeland_pointer_device_configuration_v1 object for this
+                treeland_touchpad_settings_v1 object. For the first creation,
+                the serial should be 0.
+
+                Only one treeland_pointer_device_configuration_v1 object may
+                exist for this treeland_touchpad_settings_v1 object at a time.
+                Creating a second one without destroying the first is a
+                protocol error.
+
+                If the serial does not match the current state, the compositor
+                may immediately send a failed event on the new
+                treeland_pointer_device_configuration_v1 object.
+            </description>
+            <arg name="id" type="new_id" interface="treeland_pointer_device_configuration_v1"/>
+            <arg name="serial" type="uint" summary="serial from the last done event"/>
+        </request>
+    </interface>
+
+    <interface name="treeland_keyboard_settings_v1" version="1">
+        <description summary="keyboard settings object">
+            The treeland_keyboard_settings_v1 interface represents pending
+            settings for all keyboard associated with the target seat.
+
+            Requests on this object update pending keyboard state. The
+            compositor applies the accumulated settings when the client sends
+            apply.
+
+            The compositor sends keyboard-specific state events after object
+            creation to report the current effective settings for the target
+            seat. It may later send additional state batches when those
+            effective settings change for compositor-defined reasons. A done
+            event terminates each event batch.
+        </description>
+
+        <enum name="toggle_state">
+            <entry name="off" value="0" summary="off state"/>
+            <entry name="on" value="1" summary="on state"/>
+        </enum>
+
+        <enum name="feature" bitfield="true">
+            <description summary="keyboard features">
+                Optional features supported by keyboard devices. The compositor
+                sends a feature event to indicate which features are supported
+                by at least one keyboard device associated with the target seat.
+                A client must only send a set request if the corresponding
+                feature has been advertised. It is a protocol error to send a
+                set request for a feature that has not been advertised.
+            </description>
+            <entry name="num_lock" value="1"
+                   summary="device supports configuring num lock state"/>
+        </enum>
+
+        <request name="destroy" type="destructor">
+            <description summary="destroy the keyboard settings object">
+                Destroy this treeland_keyboard_settings_v1 object.
+
+                Destroying the object discards any pending state that has not
+                yet been applied.
+            </description>
+        </request>
+
+        <request name="set_repeat">
+            <description summary="set keyboard repeat rate and delay">
+                Set the keyboard repeat rate and delay to apply on the next
+                apply request.
+
+                This request updates only the pending state tracked by this
+                object. Sending this request, or the following apply request,
+                does not by itself cause a repeat event to be emitted.
+            </description>
+            <arg name="rate" type="int"
+                 summary="repeat rate in characters per second"/>
+            <arg name="delay" type="int"
+                 summary="delay in milliseconds before repeating starts"/>
+        </request>
+
+        <request name="set_num_lock">
+            <description summary="set num lock state">
+                Set the num lock state to apply on the next apply request.
+                This request requires the num_lock feature to be advertised
+                via the feature event.
+
+                This request updates only the pending state tracked by this
+                object. Sending this request, or the following apply request,
+                does not by itself cause a num_lock event to be emitted.
+            </description>
+            <arg name="state" type="uint" enum="treeland_keyboard_settings_v1.toggle_state"
+                 summary="desired num lock state"/>
+        </request>
+
+        <request name="apply">
+            <description summary="apply pending keyboard changes">
+                Ask the compositor to apply the pending keyboard settings
+                carried by this object.
+            </description>
+        </request>
+
+        <event name="feature">
+            <description summary="report supported keyboard features">
+                This event reports which optional features are supported by at
+                least one keyboard device associated with the target seat.
+
+                The compositor sends this event as part of the initial state
+                batch after the treeland_keyboard_settings_v1 object is created.
+
+                The compositor may also send this event again when keyboard
+                devices are added to or removed from the target seat and the
+                set of supported features changes.
+            </description>
+            <arg name="feature" type="uint" enum="feature"
+                 summary="supported keyboard features"/>
+        </event>
+
+        <event name="repeat">
+            <description summary="report the current repeat configuration">
+                This event reports the current keyboard repeat configuration.
+
+                The compositor sends this event immediately after the
+                treeland_keyboard_settings_v1 object is created as part of the
+                initial keyboard state batch.
+
+                Changes requested through set_repeat do not cause this event to
+                be emitted automatically.
+            </description>
+            <arg name="rate" type="int"
+                 summary="repeat rate in characters per second"/>
+            <arg name="delay" type="int"
+                 summary="delay in milliseconds before repeating starts"/>
+        </event>
+
+        <event name="num_lock">
+            <description summary="report the current num lock state">
+                This event reports the current num lock state.
+
+                The compositor sends this event immediately after the
+                treeland_keyboard_settings_v1 object is created as part of the
+                initial keyboard state batch.
+
+                Changes requested through set_num_lock do not cause this event
+                to be emitted automatically.
+            </description>
+            <arg name="state" type="uint" enum="treeland_keyboard_settings_v1.toggle_state"
+                 summary="current num lock state"/>
+        </event>
+
+        <event name="failed">
+            <description summary="apply failed">
+                This event indicates that the compositor failed to apply one or
+                more pending keyboard settings carried by this object.
+
+                This event does not destroy the object. The client may continue
+                using the object and send further requests.
+            </description>
+        </event>
+
+        <event name="done">
+            <description summary="end of a keyboard state batch">
+                This event is sent once when all keyboard state events in the
+                current batch have been sent.
+
+                The compositor must always end a batch of keyboard state events
+                with this event, regardless of whether it sends the initial
+                state or a later update.
+            </description>
+        </event>
+    </interface>
+</protocol>


### PR DESCRIPTION
Introduce a new Wayland protocol, treeland_input_manager_v1, to allow
privileged clients to configure compositor-managed input devices.