### PR TITLE
foreign-toplevel: add attention state

### DIFF
--- a/.agents/skills/treeland-wayland-protocol/SKILL.md
+++ b/.agents/skills/treeland-wayland-protocol/SKILL.md
@@ -54,6 +54,7 @@ This skill is not for compositor/server implementation details. It only covers t
 - Avoid XML comments for protocol semantics. Put normative and behavioral information in `<description>` blocks. If a short comment is needed for maintenance, keep it non-semantic.
 - Use `since` only for backward-compatible additions inside the same major version. Do not write `since="1"`.
 - If an existing interface gains a new request or event, increment that interface's `version`, append the new member at the end of the existing request or event section, and mark the new member with the matching `since="N"`.
+- If an interface version is raised, review any nearby interface that creates it with `new_id`, returns it from a request, or exposes it from an event; if that dependency changes the observable contract for clients, raise the exposing interface `version` as well.
 - For a breaking change, keep the old XML file, add a new `-vN+1` file, rename the protocol and interfaces to the new major suffix, reset interface `version` to `1`, and remove carried-over `since` attributes.
 - Prefer precise `summary` text and concrete descriptions over placeholders.
 - Event descriptions should explain event meaning and the compositor-side trigger timing for emission.

--- a/.agents/skills/treeland-wayland-protocol/references/treeland-wayland-protocol-rules.md
+++ b/.agents/skills/treeland-wayland-protocol/references/treeland-wayland-protocol-rules.md
@@ -25,6 +25,7 @@ Backward-compatible extension:
 - add `since="N"` on each new request, event, enum entry, or arg introduced in version `N`
 - never write `since="1"`
 - append newly added requests or events after the existing ones instead of reordering old members
+- if an upgraded interface is exposed by another interface via `new_id`, a request return object, or an event object, review that exposing interface and raise its `version` too when clients need the higher version to observe or use the new contract
 
 Backward-incompatible extension:
 - create a new file with the next major version
@@ -153,6 +154,7 @@ Match the year range used by neighboring files when editing an existing protocol
 Before considering the XML finished, check:
 - file name, protocol name, and interface suffixes all agree
 - interface `version` matches the highest supported additive version
+- interfaces that create or expose upgraded interfaces were reviewed for required version bumps
 - new additions in an existing interface have `since`
 - no member is annotated with `since="1"`
 - newly added requests and events were appended without reordering older members

--- a/xml/treeland-foreign-toplevel-manager-v1.xml
+++ b/xml/treeland-foreign-toplevel-manager-v1.xml
@@ -4,7 +4,7 @@
     SPDX-FileCopyrightText: 2024 UnionTech Software Technology Co., Ltd.
     SPDX-License-Identifier: MIT
     ]]></copyright>
-    <interface name="treeland_foreign_toplevel_manager_v1" version="1">
+    <interface name="treeland_foreign_toplevel_manager_v1" version="2">
         <description summary="foreign toplevel manager">
             This interface allows a client to get toplevel some info.
 
@@ -47,7 +47,7 @@
             <arg name="id" type="new_id" interface="treeland_dock_preview_context_v1" />
         </request>
     </interface>
-    <interface name="treeland_foreign_toplevel_handle_v1" version="1">
+    <interface name="treeland_foreign_toplevel_handle_v1" version="2">
         <description summary="An opened toplevel">
             A treeland_foreign_toplevel_handle_v1 object represents an opened toplevel window. Each
             app may have multiple opened toplevels.
@@ -152,6 +152,7 @@
             <entry name="minimized" value="1" summary="the toplevel is minimized" />
             <entry name="activated" value="2" summary="the toplevel is active" />
             <entry name="fullscreen" value="3" summary="the toplevel is fullscreen" />
+            <entry name="attention" value="4" summary="the toplevel is demanding attention" since="2" />
         </enum>
 
         <event name="state">


### PR DESCRIPTION
Supports `xdg-activation-v1`, allowing windows to gain attention from the taskbar even when they do not directly receive focus; it also supports integrating with the `attention` feature of the `treeland-wine-window-state-unstable-v1` protocol.