### PR TITLE
docs: clarify virtual output validation and error codes

### DIFF
--- a/xml/treeland-virtual-output-manager-v1.xml
+++ b/xml/treeland-virtual-output-manager-v1.xml
@@ -14,10 +14,20 @@
                 on multiple screens. Virtual outputs are created to mirror multiple wl_output
                 outputs.
 
+                The name argument must not be empty. If name is empty, the compositor
+                emits an error event with code invalid_group_name.
+
                 The element of the array is the name of the screen.
 
                 The first element of the array outputs is the screen to be copied, and
                 the subsequent elements are the screens to be mirrored.
+
+                The outputs array must contain at least two elements. If the number
+                of elements is less than two, the compositor emits an error event
+                with code invalid_screen_number.
+
+                If any output name in the outputs array does not exist, the compositor
+                emits an error event with code invalid_output.
 
                 The client calling this interface will not generate an additional wl_output
                 object on the client.
@@ -29,6 +39,10 @@
         <request name="get_virtual_output_list">
             <description summary="Gets a list of virtual output names">
                 Gets a list of virtual output names.
+
+                The compositor emits one virtual_output_list event for each request.
+                Clients should avoid issuing a new get_virtual_output_list request
+                before receiving the corresponding event.
             </description>
         </request>
         <event name="virtual_output_list">
@@ -73,8 +87,10 @@
             <description summary="Screen copy mode error event">
                 When an error occurs, an error event is emitted, terminating the replication
                 mode request issued by the client.
+
+                The code argument uses treeland_virtual_output_v1.error.
             </description>
-            <arg name="code" type="uint" summary="error code" />
+            <arg name="code" type="uint" enum="treeland_virtual_output_v1.error" summary="error code" />
             <arg name="message" type="string" summary="error description" />
         </event>
         <enum name="error">


### PR DESCRIPTION
Added detailed documentation on input validation for virtual output creation, including requirements for non-empty names, minimum output array length, and existence of specified outputs. Updated error event documentation to specify error codes for each validation failure. Also clarified the behavior and usage of get_virtual_output_list requests to prevent client misuse. These changes improve protocol clarity and help developers implement correct client behavior.