### PR TITLE
feat(treeland-wine-window-management): add serial to position requests

### DIFF
--- a/xml/treeland-wine-window-management-unstable-v1.xml
+++ b/xml/treeland-wine-window-management-unstable-v1.xml
@@ -150,6 +150,12 @@
                 specified position in the compositor's global logical
                 coordinate space.
 
+                The client must supply a non-zero serial that monotonically
+                increases with each request, starting from 1.  The
+                compositor echoes this serial in the resulting
+                configure_position event so the client can correlate
+                responses to requests.
+
                 The requested position must fall within the bounds of an
                 active screen.  If the compositor determines that
                 (x, y) is outside all screen regions, it rejects the
@@ -172,6 +178,7 @@
             </description>
             <arg name="x" type="int" summary="desired x in global logical coordinates"/>
             <arg name="y" type="int" summary="desired y in global logical coordinates"/>
+            <arg name="serial" type="uint" summary="client-generated serial, starting from 1, incremented per request"/>
         </request>
 
         <request name="set_z_order">
@@ -236,6 +243,11 @@
                 - in response to set_position requests,
                 - when the user or compositor moves the window.
 
+                The serial field echoes the serial from the set_position
+                request that caused this event.  If the position change was
+                not initiated by a set_position request (e.g. initial
+                creation, user drag, or compositor policy), serial is 0.
+
                 Window size is communicated via the standard xdg_toplevel
                 configure event and is not reported here.
 
@@ -245,6 +257,7 @@
             </description>
             <arg name="x" type="int" summary="actual x in global logical coordinates"/>
             <arg name="y" type="int" summary="actual y in global logical coordinates"/>
+            <arg name="serial" type="uint" summary="echoes the set_position serial, or 0 if not in response to a client request"/>
         </event>
 
         <event name="configure_stacking">


### PR DESCRIPTION
1. Add serial argument to set_position request for request-response correlation
2. Add serial argument to configure_position event to echo the request serial

This change enables Wine clients to correctly correlate configure_position events with their set_position requests. Without the serial, clients cannot distinguish which request caused a position change when multiple requests are in flight, or determine if the change was initiated by the compositor or user interaction rather than a client