### PR TITLE
feat: add ready request for initial wallpaper synchronization

### DIFF
--- a/xml/treeland-wallpaper-shell-unstable-v1.xml
+++ b/xml/treeland-wallpaper-shell-unstable-v1.xml
@@ -110,7 +110,7 @@
         </request>
     </interface>
 
-    <interface name="treeland_wallpaper_surface_v1" version="1">
+    <interface name="treeland_wallpaper_surface_v1" version="2">
         <description summary="Wallpaper surface controller">
             The treeland_wallpaper_surface_v1 interface controls the behavior of a
             wallpaper surface.
@@ -162,6 +162,25 @@
 
             <arg name="error" type="uint" enum="error"
                 summary="The error code indicating the failure reason"/>
+        </request>
+
+        <request name="ready" since="2">
+            <description summary="Notify that wallpaper content is ready">
+                Informs the compositor that the wallpaper surface has completed
+                its initial rendering and is ready to be displayed.
+
+                The client should send this request only after a valid buffer
+                has been attached and committed to the associated wl_surface.
+
+                Before receiving this request, the compositor may keep the
+                wallpaper hidden or continue displaying a fallback wallpaper.
+
+                This request is typically used to avoid visual glitches such as
+                black frames, incomplete rendering, or uninitialized content
+                during wallpaper startup.
+
+                Calling this request multiple times has no additional effect.
+            </description>
         </request>
 
         <event name="position">


### PR DESCRIPTION
Add a new ready request to treeland_wallpaper_surface_v1 to allow wallpaper clients to explicitly notify the compositor when the wallpaper content is fully initialized and ready for display.

This improves synchronization between the client and compositor during wallpaper startup and helps avoid rendering artifacts such as black frames, incomplete content, or uninitialized buffers.

The request is expected to be sent after the client has attached and committed a valid buffer to the associated wl_surface.

Before receiving ready, the compositor may keep the wallpaper hidden or continue displaying a fallback wallpaper.

Log: add ready request for initial wallpaper synchronization
Bug: https://pms.uniontech.com/bug-view-363035.html

Influence: