### PR TITLE
feat(input-manager): remove bitfield flag from acceleration_profile enum

### DIFF
--- a/xml/treeland-input-manager-unstable-v1.xml
+++ b/xml/treeland-input-manager-unstable-v1.xml
@@ -235,7 +235,7 @@
             <entry name="left" value="1" summary="left-handed mode"/>
         </enum>
 
-        <enum name="acceleration_profile" bitfield="true">
+        <enum name="acceleration_profile">
             <description summary="pointer acceleration profiles">
                 Pointer acceleration profiles. The semantics correspond to
                 libinput acceleration profiles.


### PR DESCRIPTION
The acceleration_profile enum represents mutually exclusive pointer acceleration modes and should not be treated as a bitfield. libinput acceleration profiles are single-choice values and cannot be combined.

Remove the bitfield="true" attribute to reflect the actual semantics of the protocol enum.

Log: remove bitfield flag from acceleration_profile enum Tasks: https://pms.uniontech.com/task-view-389477.html Influence: