### PR TITLE
chore: bump version to 0.5.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.25.0)
 
-project(TreelandProtocols VERSION 0.5.7)
+project(TreelandProtocols VERSION 0.5.8)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,22 @@
+treeland-protocols (0.5.8) unstable; urgency=medium
+
+  * feat: add treeland-keyboard-state-notify-unstable-v1 protocol
+  * feat(input-manager): document valid ranges for scroll factor and
+    accel speed
+  * feat(input-manager): remove bitfield flag from acceleration_profile
+    enum
+  * feat(input-manager): clarify seat association and destruction order
+    for settings objects
+  * feat(wallpaper): document wl_output destruction order requirement
+  * feat(treeland-wine-window-management): add serial to position
+    requests
+  * feat: add ready request for initial wallpaper synchronization
+  * feat: add one-shot shortcut capture interface
+  * feat: add treeland-input-manager-unstable-v1 protocol
+  * refactor: protocol cleanup and version normalization
+
+ -- rewine <luhongxu@deepin.org>  Thu, 04 Jun 2026 16:04:48 +0800
+
 treeland-protocols (0.5.7) unstable; urgency=medium
 
   * docs: clarify virtual output validation and error codes


### PR DESCRIPTION
Log: bump

## Summary by Sourcery

Chores:
- Update Debian changelog to reflect version 0.5.8 release.