### PR TITLE
feat(personalization-manager): remove wallpaper context interface

### DIFF
--- a/xml/treeland-personalization-manager-v1.xml
+++ b/xml/treeland-personalization-manager-v1.xml
@@ -20,12 +20,6 @@
             <arg name="id" type="new_id" interface="treeland_personalization_window_context_v1" />
             <arg name="surface" type="object" interface="wl_surface" />
         </request>
-        <request name="get_wallpaper_context">
-            <description summary="custom wallpaper context">
-                custom user wallpaper
-            </description>
-            <arg name="id" type="new_id" interface="treeland_personalization_wallpaper_context_v1" />
-        </request>
         <request name="get_cursor_context">
             <description summary="custom wallpaper context">
                 custom user cursor
@@ -48,62 +42,7 @@
             <description summary="destroy treeland_personalization_manager_v1 object" />
         </request>
     </interface>
-    <interface name="treeland_personalization_wallpaper_context_v1" version="1">
-        <description summary="client custom wallpaper context">
-            This interface allows a client personalization wallpaper.
 
-            Warning! The protocol described in this file is currently in the testing
-            phase. Backward compatible changes may be added together with the
-            corresponding interface version bump. Backward incompatible changes can
-            only be done by creating a new major version of the extension.
-        </description>
-        <request name="set_fd">
-            <description summary="set the current user's wallpaper fd" />
-            <arg name="fd" type="fd" summary="wallpaper file fd" />
-            <arg name="metadata" type="string" summary="file related metadata information" />
-        </request>
-        <request name="set_identifier">
-            <description summary="identifier for the application window" />
-            <arg name="identifier" type="string" summary="Identifier for the application window" />
-        </request>
-        <enum name="options">
-            <description summary="xdg desktop portal supported keys" />
-            <entry name="preview" value="1" summary="whether to show a preview of the picture" />
-            <entry name="background" value="2" summary="configure screen background" />
-            <entry name="lockscreen" value="4" summary="configure screen wallpaper" />
-        </enum>
-        <request name="set_output">
-            <description summary="configure xdg desktop portal options" />
-            <arg name="output" type="string" summary="system output name" />
-        </request>
-        <request name="set_on">
-            <description summary="configure xdg desktop portal options" />
-            <arg name="options" type="uint" enum="options" summary="xdg desktop portal options" />
-        </request>
-        <request name="set_isdark">
-            <description summary="Set whether the current wallpaper is dark" />
-            <arg name="isdark" type="uint" summary="is dark" />
-        </request>
-        <request name="commit">
-            <description summary="commit configuration" />
-        </request>
-        <request name="get_metadata">
-            <description summary="get user save meta data">
-                get the current user's wallpaper
-            </description>
-        </request>
-        <request name="destroy" type="destructor">
-            <description summary="destroy the context object">
-                Destroy the context object.
-            </description>
-        </request>
-        <event name="metadata">
-            <description summary="get metadata event">
-                Send this signal after getting the user's wallpaper.
-            </description>
-            <arg name="metadata" type="string" summary="user meta data" />
-        </event>
-    </interface>
     <interface name="treeland_personalization_cursor_context_v1" version="1">
         <description summary="client custom cursor context">
             This interface allows a client personalization cursor.


### PR DESCRIPTION
Removes the wallpaper context interface and get_wallpaper_context
request,asthefeaturehasbeenmigratedtousexdg-desktop-portal
or other external mechanisms.

Log:removewallpapercontextfrompersonalizationmanager
PMS: BUG-355329
Influence: Broken change