### PR TITLE
chore: update changelog to 0.5.10

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+treeland-protocols (0.5.10) unstable; urgency=medium
+
+  * Release 0.5.10
+
+ -- zhangkun <zhangkun2@uniontech.com>  Wed, 17 Jun 2026 16:50:14 +0800
+
 treeland-protocols (0.5.9) unstable; urgency=medium
 
   * feat(wallpaper-shell): bump treeland_wallpaper_shell_v1 to version 2


### PR DESCRIPTION
## 更新说明

自动更新 changelog 到版本 0.5.10

### 变更内容
- 更新 debian/changelog

### 版本信息
- 新版本: 0.5.10
- 目标分支: master

## Summary by Sourcery

Chores:
- Bump Debian changelog entry to version 0.5.10 for the master branch.